### PR TITLE
Revise Data Model 2

### DIFF
--- a/app/Filament/App/Resources/StudyCaseResource.php
+++ b/app/Filament/App/Resources/StudyCaseResource.php
@@ -73,6 +73,12 @@ class StudyCaseResource extends Resource
                                 Forms\Components\Textarea::make('geographic_area')
                                     ->label(t('Geographic area'))
                                     ->hint(t('If you want to be more specific about the geographic area, please describe it here'))
+                                    // TODO: try to change border and/or background color to show structure visually
+                                    // ->extraInputAttributes(['class' => 'bg-gray-501'])
+                                    // ->extraInputAttributes(['class' => 'border-rose-600'])
+                                    // ->extraInputAttributes(['class' => 'border-2'])
+                                    // ->extraInputAttributes(['class' => 'bg-red'])
+                                    // ->extraAttributes(['class' => 'bg-gray-50'])
                                     ->rows(3)
                                     ->columnSpanFull(),
 
@@ -194,23 +200,6 @@ class StudyCaseResource extends Resource
                                             ->hint(t('Claim made in the case statement'))
                                             ->required(),
 
-                                        Forms\Components\Repeater::make('indicators')
-                                            ->label(t('Indicator(s)'))
-                                            ->relationship()
-                                            ->schema([
-                                                Forms\Components\TextInput::make('name')->label(t('Name'))->required(),
-                                                Forms\Components\Select::make('type')
-                                                    ->label(t('Type'))
-                                                    ->required()
-                                                    ->options([
-                                                        'qualitative' => 'Qualitative',
-                                                        'quantitative' => 'Quantitative',
-                                                    ]),
-                                            ])
-                                            ->defaultItems(0)
-                                            ->addActionLabel(t('Add indicator'))
-                                            ->columnSpanFull(),
-
                                         Forms\Components\Repeater::make('evidences')
                                             ->label(t('Evidence'))
                                             ->relationship()
@@ -219,6 +208,16 @@ class StudyCaseResource extends Resource
                                                     ->label(t('Evidence'))
                                                     ->hint(t('Evidence that supports this claim statement'))
                                                     ->required(),
+
+                                                Forms\Components\Repeater::make('aspects')
+                                                    ->label(t('Aspect(s)'))
+                                                    ->relationship()
+                                                    ->schema([
+                                                        Forms\Components\TextInput::make('name')->label(t('Aspect'))->required(),
+                                                    ])
+                                                    ->defaultItems(0)
+                                                    ->addActionLabel(t('Add aspect'))
+                                                    ->columnSpanFull(),
 
                                                 Forms\Components\Repeater::make('evidenceAttachments')
                                                     ->label(t('Evidence attachment(s)'))

--- a/app/Filament/App/Resources/StudyCaseResource.php
+++ b/app/Filament/App/Resources/StudyCaseResource.php
@@ -81,7 +81,6 @@ class StudyCaseResource extends Resource
                                     ->hint(t('List of partner organisation(s) that worked in the development of the case'))
                                     ->multiple()
                                     ->relationship('organisations', 'name')
-                                    ->options(auth()->user()->latestTeam->organisations->pluck('name', 'id'))
                                     ->preload()
                                     ->createOptionForm([
                                         Forms\Components\TextInput::make('name')
@@ -182,7 +181,7 @@ class StudyCaseResource extends Resource
                             ]),
 
                         Tabs\Tab::make('tab-3')
-                            ->label(t('Claims and Evidences'))
+                            ->label(t('Claims and Evidence'))
                             ->schema([
                                 Forms\Components\Repeater::make('claims')
                                     ->label(t('Claims'))
@@ -213,7 +212,7 @@ class StudyCaseResource extends Resource
                                             ->columnSpanFull(),
 
                                         Forms\Components\Repeater::make('evidences')
-                                            ->label(t('Evidence(s)'))
+                                            ->label(t('Evidence'))
                                             ->relationship()
                                             ->schema([
                                                 Forms\Components\RichEditor::make('matching_evidence')

--- a/app/Models/Aspect.php
+++ b/app/Models/Aspect.php
@@ -6,14 +6,14 @@ use App\Models\Claim;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
-class Indicator extends Model
+class Aspect extends Model
 {
-    protected $table = 'indicators';
+    protected $table = 'aspects';
 
     protected $guarded = ['id'];
 
-    public function claim(): BelongsTo
+    public function evidence(): BelongsTo
     {
-        return $this->belongsTo(Claim::class);
+        return $this->belongsTo(Evidence::class);
     }
 }

--- a/app/Models/Claim.php
+++ b/app/Models/Claim.php
@@ -18,11 +18,6 @@ class Claim extends Model
         return $this->belongsTo(StudyCase::class);
     }
 
-    public function indicators(): HasMany
-    {
-        return $this->hasMany(Indicator::class);
-    }
-
     public function evidences(): HasMany
     {
         return $this->hasMany(Evidence::class);

--- a/app/Models/Evidence.php
+++ b/app/Models/Evidence.php
@@ -18,6 +18,11 @@ class Evidence extends Model
         return $this->belongsTo(Claim::class);
     }
 
+    public function aspects(): HasMany
+    {
+        return $this->hasMany(Aspect::class);
+    }
+
     public function evidenceAttachments(): HasMany
     {
         return $this->hasMany(EvidenceAttachment::class);

--- a/database/migrations/2024_08_02_124642_create_aspects_table.php
+++ b/database/migrations/2024_08_02_124642_create_aspects_table.php
@@ -11,12 +11,10 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('indicators', function (Blueprint $table) {
+        Schema::create('aspects', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('claim_id')->constrained('claims')->onUpdate('cascade')->onDelete('cascade');;
+            $table->foreignId('evidence_id')->constrained('evidences')->onUpdate('cascade')->onDelete('cascade');;
             $table->longText('name');
-            $table->string('type');
-            $table->text('note')->nullable();
             $table->timestamps();
         });
     }
@@ -26,6 +24,6 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('indicators');
+        Schema::dropIfExists('aspects');
     }
 };


### PR DESCRIPTION
This PR is submitted to revise data struture of claim, evidence and indicators.

This PR contains below changes:
1. Change label for evidence(s). Evidence is an uncountable noun, we can just call it evidence no matter it is plural or singular form. (I did not change table name and relationship name from "evidences" to "evidence" as long as it is working fine in Laravel.)
2. Change indicator to aspect
3. Aspects belong to evidence instead of claim. 
    - To have a clear relationship between evidence and aspect. So that we can know which aspect is related to which evidence clearly.

---

BEFORE:
claim : evidence (1:M)
claim : indicator (1:M)

claim 1
  - evidence 1
  - evidence 2
  - indicator 1
  - indicator 2
  - indicator 3

---

AFTER:
claim : evidence (1:M)
evidence : aspect (1:M)

claim 1
  - evidence 1
    - aspect 11
    - aspect 12
  - evidence 2
    - aspect 21

---

Staging env deployment
 - We are in early stage of development, it is common to have refinements for data strcture. 
 - To ease deployment in staging env, all existing testing records will be deleted. User will need to create new case record for testing.