### PR TITLE
Add Default Login Accounts

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -13,20 +13,16 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // User::factory(10)->create();
-
-        User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
-        ]);
-
         $this->call(PermissionsTableSeeder::class);
         $this->call(RolesTableSeeder::class);
         $this->call(RoleHasPermissionsTableSeeder::class);
-        $this->call(TagsTableSeeder::class);
+
         $this->call(TeamsTableSeeder::class);
+        $this->call(UsersTableSeeder::class);
         $this->call(TeamMembersTableSeeder::class);
         $this->call(OrganisationsTableSeeder::class);
+
+        $this->call(TagsTableSeeder::class);
         $this->call(CountriesTableSeeder::class);
         $this->call(LanguagesTableSeeder::class);
     }

--- a/database/seeders/TeamMembersTableSeeder.php
+++ b/database/seeders/TeamMembersTableSeeder.php
@@ -28,6 +28,33 @@ class TeamMembersTableSeeder extends Seeder
                 'created_at' => NULL,
                 'updated_at' => NULL,
             ),
+            1 => 
+            array (
+                'id' => 2,
+                'team_id' => 2,
+                'user_id' => 2,
+                'is_admin' => 0,
+                'created_at' => NULL,
+                'updated_at' => NULL,
+            ),
+            2 => 
+            array (
+                'id' => 3,
+                'team_id' => 2,
+                'user_id' => 3,
+                'is_admin' => 0,
+                'created_at' => NULL,
+                'updated_at' => NULL,
+            ),
+            3 => 
+            array (
+                'id' => 4,
+                'team_id' => 2,
+                'user_id' => 4,
+                'is_admin' => 0,
+                'created_at' => NULL,
+                'updated_at' => NULL,
+            ),
         ));
         
         

--- a/database/seeders/TeamsTableSeeder.php
+++ b/database/seeders/TeamsTableSeeder.php
@@ -31,6 +31,18 @@ class TeamsTableSeeder extends Seeder
                 'created_at' => '2024-08-15 10:22:09',
                 'updated_at' => '2024-08-15 10:22:09',
             ),
+            1 => 
+            array (
+                'id' => 2,
+                'name' => 'Reviewer Team',
+                'website' => NULL,
+                'contact_person_name' => NULL,
+                'contact_person_email' => NULL,
+                'description' => NULL,
+                'avatar' => NULL,
+                'created_at' => '2024-08-22 09:09:22',
+                'updated_at' => '2024-08-22 09:09:22',
+            ),
         ));
         
         

--- a/database/seeders/UsersTableSeeder.php
+++ b/database/seeders/UsersTableSeeder.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+
+class UsersTableSeeder extends Seeder
+{
+
+    /**
+     * Auto generated seed file
+     *
+     * @return void
+     */
+    public function run()
+    {
+        
+
+        \DB::table('users')->delete();
+        
+        \DB::table('users')->insert(array (
+            0 => 
+            array (
+                'id' => 1,
+                'name' => 'Test User',
+                'email' => 'test@example.com',
+                'email_verified_at' => '2024-08-22 08:24:35',
+                'password' => '$2y$12$ojE8ci3ZPy.CBq70/A.3denaNeAaF/vJnPMvjRHdKYlP1tT25NG..',
+                'remember_token' => 'gFyKpWaJN59kcHWdwSzfLwMPRevaBgfAkKlQcwnvxJuk7PkgU0CRMi6lQwvv',
+                'created_at' => '2024-08-22 08:24:35',
+                'updated_at' => '2024-08-22 08:25:25',
+                'latest_team_id' => 1,
+            ),
+            1 => 
+            array (
+                'id' => 2,
+                'name' => 'Dan Tang',
+                'email' => 'dan@stats4sd.org',
+                'email_verified_at' => NULL,
+                'password' => '$2y$12$R/THQxRLrAiI2NG5WRcBiu1PjYtrUV0SgSlRaLOPEFYI7croAmtIW',
+                'remember_token' => NULL,
+                'created_at' => '2024-08-22 09:06:29',
+                'updated_at' => '2024-08-22 09:09:23',
+                'latest_team_id' => 2,
+            ),
+            2 => 
+            array (
+                'id' => 3,
+                'name' => 'Carlos Barahona',
+                'email' => 'c.e.barahona@stats4sd.org',
+                'email_verified_at' => NULL,
+                'password' => '$2y$12$T8pqt7sW9a3LkcaiMFjXN.Y2bTk8hJ.exZBqKwj7OToSqNFYEVGWm',
+                'remember_token' => NULL,
+                'created_at' => '2024-08-22 09:07:17',
+                'updated_at' => '2024-08-22 09:11:49',
+                'latest_team_id' => 2,
+            ),
+            3 => 
+            array (
+                'id' => 4,
+                'name' => 'Romina De Angelis',
+                'email' => 'romina@stats4sd.org',
+                'email_verified_at' => NULL,
+                'password' => '$2y$12$OwnmbJtvb.wiSdLGFzTuAup6hyJRW.QZaSsFZuLk5CxLsUX9Zzz4.',
+                'remember_token' => NULL,
+                'created_at' => '2024-08-22 09:07:31',
+                'updated_at' => '2024-08-22 09:07:31',
+                'latest_team_id' => NULL,
+            ),
+        ));
+        
+        
+    }
+}


### PR DESCRIPTION
This PR is submitted to add default login accounts and teams.
This is to ease the account creation and team creation process after refreshing database with seeder files in staging env.

This PR contains below changes:
1. Add default user accounts and teams to seeder files

---

Staging env deployment
 - remote to server, run command "php artisan migrate:fresh --seed"
 - login with different default user accounts