### PR TITLE
Revise Study Case Page 3

### DIFF
--- a/app/Filament/Admin/Resources/StudyCaseResource.php
+++ b/app/Filament/Admin/Resources/StudyCaseResource.php
@@ -299,18 +299,22 @@ class StudyCaseResource extends Resource
                         Tabs\Tab::make('tab-5')
                             ->label(t('Confirmation'))
                             ->schema([
-                                // This checkbox is for user only, not for reviewer
+                                // This checkbox is for submitter only, not for reviewer
+                                // It should be disabled in admin panel
                                 Forms\Components\Checkbox::make('ready_for_review')
                                     ->label(t('I confirm that all content is correct. This case is now ready for reviewer to review.'))
+                                    ->hint(t('This is to be confirmed by case submitter'))
                                     ->disabled()
                                     ->columnSpanFull(),
 
-                                // This checkbox is for reviewer only
+                                // This checkbox is for reviewer only, not for submitter
+                                // It should be disabled in app panel
                                 Forms\Components\Checkbox::make('reviewed')
                                     ->label(t('I confirm that all content has been reviewed. This case is now ready for publishing.'))
+                                    ->hint(t('This is to be confirmed by case reviewer'))
+                                    // ->disabled()
                                     ->columnSpanFull(),
                             ]),
-
 
                     ])->columnSpanFull()
                     ->persistTabInQueryString()

--- a/app/Filament/Admin/Resources/StudyCaseResource.php
+++ b/app/Filament/Admin/Resources/StudyCaseResource.php
@@ -43,19 +43,32 @@ class StudyCaseResource extends Resource
                     ->tabs([
                         Tabs\Tab::make('tab-1')
                             ->label(t('Basic Information'))
+                            ->icon('heroicon-m-information-circle')
                             ->schema([
+
+                                Forms\Components\TextInput::make('title')
+                                    ->label(t('Title'))
+                                    ->required()
+                                    ->columnSpanFull(),
+
+                                Forms\Components\TextInput::make('year_of_development')
+                                    ->label(t('Year of development'))
+                                    ->required()
+                                    ->numeric(),
 
                                 Forms\Components\Select::make('languages')
                                     ->label(t('Language(s)'))
                                     ->hint(t('An initial list of language(s) will be provided, but if the language of your case is not listed, you will be able to type it.'))
                                     ->multiple()
                                     ->relationship('languages', 'name')
+                                    ->required()
                                     ->preload(),
 
                                 Forms\Components\Select::make('tags')
                                     ->label(t('Tag(s) / keyword(s)'))
                                     ->multiple()
                                     ->relationship('tags', 'name')
+                                    ->required()
                                     ->preload()
                                     ->createOptionForm([
                                         Forms\Components\TextInput::make('name')
@@ -69,12 +82,20 @@ class StudyCaseResource extends Resource
                                     ->hint(t('Select the country(ies) covered in your case'))
                                     ->multiple()
                                     ->relationship('countries', 'name')
+                                    ->required()
                                     ->preload(),
 
                                 Forms\Components\Textarea::make('geographic_area')
                                     ->label(t('Geographic area'))
                                     ->hint(t('If you want to be more specific about the geographic area, please describe it here'))
+                                    // TODO: try to change border and/or background color to show structure visually
+                                    // ->extraInputAttributes(['class' => 'bg-gray-501'])
+                                    // ->extraInputAttributes(['class' => 'border-rose-600'])
+                                    // ->extraInputAttributes(['class' => 'border-2'])
+                                    // ->extraInputAttributes(['class' => 'bg-red'])
+                                    // ->extraAttributes(['class' => 'bg-gray-50'])
                                     ->rows(3)
+                                    ->required()
                                     ->columnSpanFull(),
 
                                 Forms\Components\Select::make('organisations')
@@ -83,6 +104,7 @@ class StudyCaseResource extends Resource
                                     ->multiple()
                                     ->relationship('organisations', 'name')
                                     ->preload()
+                                    ->required()
                                     ->createOptionForm([
                                         Forms\Components\TextInput::make('name')
                                             ->label(t('Name'))
@@ -108,15 +130,9 @@ class StudyCaseResource extends Resource
 
                         Tabs\Tab::make('tab-2')
                             ->label(t('Case Details'))
+                            ->icon('heroicon-m-document-text')
+                            ->disabled($form->getRecord() == null)
                             ->schema([
-                                Forms\Components\TextInput::make('year_of_development')
-                                    ->label(t('Year of development'))
-                                    ->numeric(),
-
-                                Forms\Components\Textarea::make('title')
-                                    ->label(t('Title'))
-                                    ->rows(10)
-                                    ->columnSpanFull(),
 
                                 Forms\Components\RichEditor::make('statement')
                                     ->label(t('Statement(s)'))
@@ -183,6 +199,8 @@ class StudyCaseResource extends Resource
 
                         Tabs\Tab::make('tab-3')
                             ->label(t('Claims and Evidence'))
+                            ->icon('heroicon-m-sparkles')
+                            ->disabled($form->getRecord() == null)
                             ->schema([
                                 Forms\Components\Repeater::make('claims')
                                     ->label(t('Claims'))
@@ -215,21 +233,21 @@ class StudyCaseResource extends Resource
                                                     ->columnSpanFull(),
 
                                                 Forms\Components\Repeater::make('evidenceAttachments')
-                                                    ->label(t('Evidence attachment(s)'))
+                                                    ->label(t('Source(s) of the evidence'))
                                                     ->hint(t('Description, web address and link to upload evidence attachment: documents, videos and/or audio files'))
                                                     ->relationship()
                                                     ->schema([
                                                         TextInput::make('description')->label(t('Description'))->required(),
                                                         TextInput::make('url')->label(t('URL')),
-                                                        // TODO: add restriction for file size
                                                         Forms\Components\SpatieMediaLibraryFileUpload::make('file')
                                                             ->label(t('File'))
                                                             ->collection('file')
                                                             ->preserveFilenames()
-                                                            ->downloadable(),
+                                                            ->downloadable()
+                                                            ->maxSize(10240),
                                                     ])
                                                     ->defaultItems(0)
-                                                    ->addActionLabel(t('Add evidence attachment'))
+                                                    ->addActionLabel(t('Add source of the evidence'))
                                                     ->columnSpanFull(),
 
                                             ])
@@ -246,7 +264,10 @@ class StudyCaseResource extends Resource
 
                         Tabs\Tab::make('tab-4')
                             ->label(t('Others'))
+                            ->icon('heroicon-m-paper-clip')
+                            ->disabled($form->getRecord() == null)
                             ->schema([
+
                                 Forms\Components\Repeater::make('communicationProducts')
                                     ->label(t('Communication product(s)'))
                                     ->hint(t('Description, web address and link to upload communication products: documents, videos and/or audio files'))
@@ -254,12 +275,12 @@ class StudyCaseResource extends Resource
                                     ->schema([
                                         TextInput::make('description')->label(t('Description'))->required(),
                                         TextInput::make('url')->label(t('URL')),
-                                        // TODO: add restriction for file size
                                         Forms\Components\SpatieMediaLibraryFileUpload::make('file')
                                             ->label(t('File'))
                                             ->collection('file')
                                             ->preserveFilenames()
-                                            ->downloadable(),
+                                            ->downloadable()
+                                            ->maxSize(10240),
                                     ])
                                     ->defaultItems(0)
                                     ->addActionLabel(t('Add communication product'))
@@ -272,32 +293,38 @@ class StudyCaseResource extends Resource
                                     ->schema([
                                         TextInput::make('description')->label(t('Description'))->required(),
                                         TextInput::make('url')->label(t('URL')),
-                                        // TODO: add restriction for file size
                                         Forms\Components\SpatieMediaLibraryFileUpload::make('file')
                                             ->label(t('File'))
                                             ->collection('file')
                                             ->preserveFilenames()
-                                            ->downloadable(),
+                                            ->downloadable()
+                                            ->maxSize(10240),
                                     ])
                                     ->defaultItems(0)
                                     ->addActionLabel(t('Add bibliography and reference'))
                                     ->columnSpanFull(),
 
-                                // TODO: add restriction for file size
-                                // TODO: add restriction for image files only
+                                // TODO: not sure how to add description as custom properties in SpatieMediaLibraryFileUpload...
+                                // TODO: unable to add restriction to only accept image files, because acceptsMimeTypes() is not supported in filament plugins
                                 Forms\Components\SpatieMediaLibraryFileUpload::make('photos')
                                     ->label(t('Catalogue photos'))
                                     ->hint(t('Please upload here up to 5 photos for the case entry into the catalogue. These photos will help us make your entry in the catalogue look great!'))
                                     ->collection('photos')
                                     ->multiple()
-                                    ->preserveFilenames()
+                                    ->reorderable()
                                     ->downloadable()
+                                    ->preserveFilenames()
+                                    // ->acceptsMimeTypes(['image/jpeg'])
                                     ->maxFiles(5)
+                                    // set maximum file size is 10 MB
+                                    ->maxSize(10240)
                                     ->columnSpanFull(),
                             ]),
 
                         Tabs\Tab::make('tab-5')
                             ->label(t('Confirmation'))
+                            ->icon('heroicon-m-check-circle')
+                            ->disabled($form->getRecord() == null)
                             ->schema([
                                 // This checkbox is for submitter only, not for reviewer
                                 // It should be disabled in admin panel

--- a/app/Filament/App/Resources/StudyCaseResource.php
+++ b/app/Filament/App/Resources/StudyCaseResource.php
@@ -46,17 +46,29 @@ class StudyCaseResource extends Resource
                             ->icon('heroicon-m-information-circle')
                             ->schema([
 
+                                Forms\Components\TextInput::make('title')
+                                    ->label(t('Title'))
+                                    ->required()
+                                    ->columnSpanFull(),
+
+                                Forms\Components\TextInput::make('year_of_development')
+                                    ->label(t('Year of development'))
+                                    ->required()
+                                    ->numeric(),
+
                                 Forms\Components\Select::make('languages')
                                     ->label(t('Language(s)'))
                                     ->hint(t('An initial list of language(s) will be provided, but if the language of your case is not listed, you will be able to type it.'))
                                     ->multiple()
                                     ->relationship('languages', 'name')
+                                    ->required()
                                     ->preload(),
 
                                 Forms\Components\Select::make('tags')
                                     ->label(t('Tag(s) / keyword(s)'))
                                     ->multiple()
                                     ->relationship('tags', 'name')
+                                    ->required()
                                     ->preload()
                                     ->createOptionForm([
                                         Forms\Components\TextInput::make('name')
@@ -70,6 +82,7 @@ class StudyCaseResource extends Resource
                                     ->hint(t('Select the country(ies) covered in your case'))
                                     ->multiple()
                                     ->relationship('countries', 'name')
+                                    ->required()
                                     ->preload(),
 
                                 Forms\Components\Textarea::make('geographic_area')
@@ -82,6 +95,7 @@ class StudyCaseResource extends Resource
                                     // ->extraInputAttributes(['class' => 'bg-red'])
                                     // ->extraAttributes(['class' => 'bg-gray-50'])
                                     ->rows(3)
+                                    ->required()
                                     ->columnSpanFull(),
 
                                 Forms\Components\Select::make('organisations')
@@ -90,6 +104,7 @@ class StudyCaseResource extends Resource
                                     ->multiple()
                                     ->relationship('organisations', 'name')
                                     ->preload()
+                                    ->required()
                                     ->createOptionForm([
                                         Forms\Components\TextInput::make('name')
                                             ->label(t('Name'))
@@ -118,14 +133,6 @@ class StudyCaseResource extends Resource
                             ->icon('heroicon-m-document-text')
                             ->disabled($form->getRecord() == null)
                             ->schema([
-                                Forms\Components\TextInput::make('year_of_development')
-                                    ->label(t('Year of development'))
-                                    ->numeric(),
-
-                                Forms\Components\Textarea::make('title')
-                                    ->label(t('Title'))
-                                    ->rows(10)
-                                    ->columnSpanFull(),
 
                                 Forms\Components\RichEditor::make('statement')
                                     ->label(t('Statement(s)'))
@@ -226,7 +233,7 @@ class StudyCaseResource extends Resource
                                                     ->columnSpanFull(),
 
                                                 Forms\Components\Repeater::make('evidenceAttachments')
-                                                    ->label(t('Evidence attachment(s)'))
+                                                    ->label(t('Source(s) of the evidence'))
                                                     ->hint(t('Description, web address and link to upload evidence attachment: documents, videos and/or audio files'))
                                                     ->relationship()
                                                     ->schema([
@@ -240,7 +247,7 @@ class StudyCaseResource extends Resource
                                                             ->maxSize(10240),
                                                     ])
                                                     ->defaultItems(0)
-                                                    ->addActionLabel(t('Add evidence attachment'))
+                                                    ->addActionLabel(t('Add source of the evidence'))
                                                     ->columnSpanFull(),
 
                                             ])

--- a/app/Filament/App/Resources/StudyCaseResource.php
+++ b/app/Filament/App/Resources/StudyCaseResource.php
@@ -43,6 +43,7 @@ class StudyCaseResource extends Resource
                     ->tabs([
                         Tabs\Tab::make('tab-1')
                             ->label(t('Basic Information'))
+                            ->icon('heroicon-m-information-circle')
                             ->schema([
 
                                 Forms\Components\Select::make('languages')
@@ -114,6 +115,8 @@ class StudyCaseResource extends Resource
 
                         Tabs\Tab::make('tab-2')
                             ->label(t('Case Details'))
+                            ->icon('heroicon-m-document-text')
+                            ->disabled($form->getRecord() == null)
                             ->schema([
                                 Forms\Components\TextInput::make('year_of_development')
                                     ->label(t('Year of development'))
@@ -189,6 +192,8 @@ class StudyCaseResource extends Resource
 
                         Tabs\Tab::make('tab-3')
                             ->label(t('Claims and Evidence'))
+                            ->icon('heroicon-m-sparkles')
+                            ->disabled($form->getRecord() == null)
                             ->schema([
                                 Forms\Components\Repeater::make('claims')
                                     ->label(t('Claims'))
@@ -227,12 +232,12 @@ class StudyCaseResource extends Resource
                                                     ->schema([
                                                         TextInput::make('description')->label(t('Description'))->required(),
                                                         TextInput::make('url')->label(t('URL')),
-                                                        // TODO: add restriction for file size
                                                         Forms\Components\SpatieMediaLibraryFileUpload::make('file')
                                                             ->label(t('File'))
                                                             ->collection('file')
                                                             ->preserveFilenames()
-                                                            ->downloadable(),
+                                                            ->downloadable()
+                                                            ->maxSize(10240),
                                                     ])
                                                     ->defaultItems(0)
                                                     ->addActionLabel(t('Add evidence attachment'))
@@ -252,6 +257,8 @@ class StudyCaseResource extends Resource
 
                         Tabs\Tab::make('tab-4')
                             ->label(t('Others'))
+                            ->icon('heroicon-m-paper-clip')
+                            ->disabled($form->getRecord() == null)
                             ->schema([
 
                                 Forms\Components\Repeater::make('communicationProducts')
@@ -261,12 +268,12 @@ class StudyCaseResource extends Resource
                                     ->schema([
                                         TextInput::make('description')->label(t('Description'))->required(),
                                         TextInput::make('url')->label(t('URL')),
-                                        // TODO: add restriction for file size
                                         Forms\Components\SpatieMediaLibraryFileUpload::make('file')
                                             ->label(t('File'))
                                             ->collection('file')
                                             ->preserveFilenames()
-                                            ->downloadable(),
+                                            ->downloadable()
+                                            ->maxSize(10240),
                                     ])
                                     ->defaultItems(0)
                                     ->addActionLabel(t('Add communication product'))
@@ -279,12 +286,12 @@ class StudyCaseResource extends Resource
                                     ->schema([
                                         TextInput::make('description')->label(t('Description'))->required(),
                                         TextInput::make('url')->label(t('URL')),
-                                        // TODO: add restriction for file size
                                         Forms\Components\SpatieMediaLibraryFileUpload::make('file')
                                             ->label(t('File'))
                                             ->collection('file')
                                             ->preserveFilenames()
-                                            ->downloadable(),
+                                            ->downloadable()
+                                            ->maxSize(10240),
                                     ])
                                     ->defaultItems(0)
                                     ->addActionLabel(t('Add bibliography and reference'))
@@ -309,6 +316,8 @@ class StudyCaseResource extends Resource
 
                         Tabs\Tab::make('tab-5')
                             ->label(t('Confirmation'))
+                            ->icon('heroicon-m-check-circle')
+                            ->disabled($form->getRecord() == null)
                             ->schema([
                                 // This checkbox is for submitter only, not for reviewer
                                 // It should be disabled in admin panel

--- a/app/Filament/App/Resources/StudyCaseResource.php
+++ b/app/Filament/App/Resources/StudyCaseResource.php
@@ -7,11 +7,12 @@ use Filament\Tables;
 use Filament\Forms\Form;
 use App\Models\StudyCase;
 use Filament\Tables\Table;
-use Filament\Forms\Components\Tabs;
 use App\Models\Organisation;
 use Filament\Resources\Resource;
+use Filament\Forms\Components\Tabs;
 use Filament\Forms\Components\TextInput;
 use Illuminate\Database\Eloquent\Builder;
+use Filament\Forms\Components\Builder\Block;
 use Illuminate\Database\Eloquent\SoftDeletingScope;
 use App\Filament\App\Resources\StudyCaseResource\Pages;
 use App\Filament\App\Resources\StudyCaseResource\RelationManagers;
@@ -252,6 +253,7 @@ class StudyCaseResource extends Resource
                         Tabs\Tab::make('tab-4')
                             ->label(t('Others'))
                             ->schema([
+
                                 Forms\Components\Repeater::make('communicationProducts')
                                     ->label(t('Communication product(s)'))
                                     ->hint(t('Description, web address and link to upload communication products: documents, videos and/or audio files'))
@@ -288,34 +290,42 @@ class StudyCaseResource extends Resource
                                     ->addActionLabel(t('Add bibliography and reference'))
                                     ->columnSpanFull(),
 
-                                // TODO: add restriction for file size
-                                // TODO: add restriction for image files only
+                                // TODO: not sure how to add description as custom properties in SpatieMediaLibraryFileUpload...
+                                // TODO: unable to add restriction to only accept image files, because acceptsMimeTypes() is not supported in filament plugins
                                 Forms\Components\SpatieMediaLibraryFileUpload::make('photos')
                                     ->label(t('Catalogue photos'))
                                     ->hint(t('Please upload here up to 5 photos for the case entry into the catalogue. These photos will help us make your entry in the catalogue look great!'))
                                     ->collection('photos')
                                     ->multiple()
-                                    ->preserveFilenames()
+                                    ->reorderable()
                                     ->downloadable()
+                                    ->preserveFilenames()
+                                    // ->acceptsMimeTypes(['image/jpeg'])
                                     ->maxFiles(5)
+                                    // set maximum file size is 10 MB
+                                    ->maxSize(10240)
                                     ->columnSpanFull(),
                             ]),
 
                         Tabs\Tab::make('tab-5')
                             ->label(t('Confirmation'))
                             ->schema([
-                                // This checkbox is for user only, not for reviewer
+                                // This checkbox is for submitter only, not for reviewer
+                                // It should be disabled in admin panel
                                 Forms\Components\Checkbox::make('ready_for_review')
                                     ->label(t('I confirm that all content is correct. This case is now ready for reviewer to review.'))
+                                    ->hint(t('This is to be confirmed by case submitter'))
                                     // ->disabled()
                                     ->columnSpanFull(),
 
-                                // This checkbox is for reviewer only
-                                // Forms\Components\Checkbox::make('reviewed')
-                                //     ->label(t('I confirm that all content has been reviewed. This case is now ready for publishing.'))
-                                //     ->columnSpanFull(),
+                                // This checkbox is for reviewer only, not for submitter
+                                // It should be disabled in app panel
+                                Forms\Components\Checkbox::make('reviewed')
+                                    ->label(t('I confirm that all content has been reviewed. This case is now ready for publishing.'))
+                                    ->hint(t('This is to be confirmed by case reviewer'))
+                                    ->disabled()
+                                    ->columnSpanFull(),
                             ]),
-
 
                     ])->columnSpanFull()
                     ->persistTabInQueryString()

--- a/app/Filament/App/Resources/StudyCaseResource/Pages/CreateStudyCase.php
+++ b/app/Filament/App/Resources/StudyCaseResource/Pages/CreateStudyCase.php
@@ -10,6 +10,11 @@ class CreateStudyCase extends CreateRecord
 {
     protected static string $resource = StudyCaseResource::class;
 
+    public function getSubheading(): ?string
+    {
+        return __(t('Please kindly fill in all basic information first. After creating a new case, you can fill in details in all other tabs.'));
+    }
+
     protected function mutateFormDataBeforeCreate(array $data): array
     {
         $data['team_id'] = auth()->user()->latestTeam->id;
@@ -17,6 +22,7 @@ class CreateStudyCase extends CreateRecord
         return $data;
     }
 
+    // TODO: redirect to Edit view after creating new record
     protected function getRedirectUrl(): string
     {
         return $this->getResource()::getUrl('index');

--- a/database/migrations/2024_08_02_124151_create_claims_table.php
+++ b/database/migrations/2024_08_02_124151_create_claims_table.php
@@ -13,7 +13,7 @@ return new class extends Migration
     {
         Schema::create('claims', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('study_case_id')->constrained('study_cases')->onUpdate('cascade')->onDelete('cascade');
+            $table->foreignId('study_case_id')->constrained('study_cases')->cascadeOnDelete()->cascadeOnUpdate();
             $table->longText('claim_statement');
             $table->timestamps();
         });

--- a/database/migrations/2024_08_02_124432_create_evidences_table.php
+++ b/database/migrations/2024_08_02_124432_create_evidences_table.php
@@ -13,7 +13,7 @@ return new class extends Migration
     {
         Schema::create('evidences', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('claim_id')->constrained('claims')->onUpdate('cascade')->onDelete('cascade');;
+            $table->foreignId('claim_id')->constrained('claims')->cascadeOnDelete()->cascadeOnUpdate();
             $table->longText('matching_evidence');
             $table->timestamps();
         });

--- a/database/migrations/2024_08_02_124642_create_aspects_table.php
+++ b/database/migrations/2024_08_02_124642_create_aspects_table.php
@@ -13,7 +13,7 @@ return new class extends Migration
     {
         Schema::create('aspects', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('evidence_id')->constrained('evidences')->onUpdate('cascade')->onDelete('cascade');;
+            $table->foreignId('evidence_id')->constrained('evidences')->cascadeOnDelete()->cascadeOnUpdate();
             $table->longText('name');
             $table->timestamps();
         });

--- a/database/migrations/2024_08_02_124726_create_communication_products_table.php
+++ b/database/migrations/2024_08_02_124726_create_communication_products_table.php
@@ -13,7 +13,7 @@ return new class extends Migration
     {
         Schema::create('communication_products', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('study_case_id')->constrained('study_cases')->onUpdate('cascade')->onDelete('cascade');
+            $table->foreignId('study_case_id')->constrained('study_cases')->cascadeOnDelete()->cascadeOnUpdate();
             $table->string('description')->nullable();;
             $table->string('url')->nullable();;
             $table->timestamps();

--- a/database/migrations/2024_08_02_124848_create_evidence_attachments_table.php
+++ b/database/migrations/2024_08_02_124848_create_evidence_attachments_table.php
@@ -13,7 +13,7 @@ return new class extends Migration
     {
         Schema::create('evidence_attachments', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('evidence_id')->constrained('evidences')->onUpdate('cascade')->onDelete('cascade');;
+            $table->foreignId('evidence_id')->constrained('evidences')->cascadeOnDelete()->cascadeOnUpdate();
             $table->string('description')->nullable();;
             $table->string('url')->nullable();;
             $table->timestamps();

--- a/database/migrations/2024_08_02_124848_create_references_table.php
+++ b/database/migrations/2024_08_02_124848_create_references_table.php
@@ -13,7 +13,7 @@ return new class extends Migration
     {
         Schema::create('references', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('study_case_id')->constrained('study_cases')->onUpdate('cascade')->onDelete('cascade');;
+            $table->foreignId('study_case_id')->constrained('study_cases')->cascadeOnDelete()->cascadeOnUpdate();
             $table->string('description')->nullable();;
             $table->string('url')->nullable();;
             $table->timestamps();

--- a/database/migrations/2024_08_02_125209_create_study_case_organisation_table.php
+++ b/database/migrations/2024_08_02_125209_create_study_case_organisation_table.php
@@ -13,8 +13,8 @@ return new class extends Migration
     {
         Schema::create('organisation_study_case', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('organisation_id')->constrained('organisations');
-            $table->foreignId('study_case_id')->constrained('study_cases');
+            $table->foreignId('organisation_id')->constrained('organisations')->cascadeOnDelete()->cascadeOnUpdate();
+            $table->foreignId('study_case_id')->constrained('study_cases')->cascadeOnDelete()->cascadeOnUpdate();
             $table->timestamps();
         });
     }
@@ -24,6 +24,6 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('study_case_organisation');
+        Schema::dropIfExists('organisation_study_case');
     }
 };

--- a/database/migrations/2024_08_02_143100_create_study_case_tag_table.php
+++ b/database/migrations/2024_08_02_143100_create_study_case_tag_table.php
@@ -13,8 +13,8 @@ return new class extends Migration
     {
         Schema::create('study_case_tag', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('study_case_id')->constrained('study_cases');
-            $table->foreignId('tag_id')->constrained('tags');
+            $table->foreignId('study_case_id')->constrained('study_cases')->cascadeOnDelete()->cascadeOnUpdate();
+            $table->foreignId('tag_id')->constrained('tags')->cascadeOnDelete()->cascadeOnUpdate();
             $table->timestamps();
         });
     }

--- a/database/migrations/2024_08_07_135801_21_create_team_members_table.php
+++ b/database/migrations/2024_08_07_135801_21_create_team_members_table.php
@@ -12,8 +12,8 @@ return new class extends Migration {
     {
         Schema::create('team_members', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->foreignId('team_id')->constrained('teams')->onUpdate('cascade')->onDelete('cascade');
-            $table->foreignId('user_id')->constrained('users')->onUpdate('cascade')->onDelete('cascade');
+            $table->foreignId('team_id')->constrained('teams')->cascadeOnDelete()->cascadeOnUpdate();
+            $table->foreignId('user_id')->constrained('users')->cascadeOnDelete()->cascadeOnUpdate();
             $table->boolean('is_admin')->default(false);
             $table->timestamps();
         });

--- a/database/migrations/2024_08_19_094733_create_country_study_case_table.php
+++ b/database/migrations/2024_08_19_094733_create_country_study_case_table.php
@@ -13,8 +13,8 @@ return new class extends Migration
     {
         Schema::create('country_study_case', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('country_id')->constrained('countries');
-            $table->foreignId('study_case_id')->constrained('study_cases');
+            $table->foreignId('country_id')->constrained('countries')->cascadeOnDelete()->cascadeOnUpdate();
+            $table->foreignId('study_case_id')->constrained('study_cases')->cascadeOnDelete()->cascadeOnUpdate();
             $table->timestamps();
         });
     }
@@ -24,6 +24,6 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('country_studycase');
+        Schema::dropIfExists('country_study_case');
     }
 };

--- a/database/migrations/2024_08_19_103217_create_language_study_case_table.php
+++ b/database/migrations/2024_08_19_103217_create_language_study_case_table.php
@@ -13,8 +13,8 @@ return new class extends Migration
     {
         Schema::create('language_study_case', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('language_id')->constrained('languages');
-            $table->foreignId('study_case_id')->constrained('study_cases');
+            $table->foreignId('language_id')->constrained('languages')->cascadeOnDelete()->cascadeOnUpdate();
+            $table->foreignId('study_case_id')->constrained('study_cases')->cascadeOnDelete()->cascadeOnUpdate();
             $table->timestamps();
         });
     }


### PR DESCRIPTION
This PR contains below changes:
1. Move title and year of development from 2nd tab to 1st tab
2. When user is creating a new record, disable tab 2 to tab 5. User should fill in details in tab 1 to create record first
3. Set most of the columns as complusory in 1st tab
4. Update label, change "Evidence attachments" to "Sources of the evidence"
5. Add subheading in study case create view
6. Apply cascadeOnDelete() and cascadeOnUpdate() to all pivot tables