### PR TITLE
Add Admin Panel Button

### DIFF
--- a/app/Http/Middleware/CheckIfAdmin.php
+++ b/app/Http/Middleware/CheckIfAdmin.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Models\User;
+use Closure;
+use Illuminate\Http\Request;
+use Spatie\Permission\Models\Role;
+use Symfony\Component\HttpFoundation\Response;
+
+class CheckIfAdmin
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        // Check if the user is an admin
+        if (! auth()->user()->isAdmin()) {
+            abort(403, 'Only platform administrators can access this page');
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Http/Responses/RegisterResponse.php
+++ b/app/Http/Responses/RegisterResponse.php
@@ -13,8 +13,11 @@ class RegisterResponse implements RegistrationResponse
     public function toResponse($request)
     {
         // redirect user to admin panel (for admin user) or app panel (for non admin user) after user registration
+        // $home = auth()->user()->is_admin ? '/admin' : '/app';
 
-        $home = auth()->user()->is_admin ? '/admin' : '/app';
+        // always redirect user to app panel, as app panel is the only entry point of this application.
+        // admin user can go to admin panel via Admin panel menu item in sidebar
+        $home = '/app';
 
         return redirect()->intended($home);
     }

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -38,10 +38,10 @@ class AdminPanelProvider extends PanelProvider
     public function panel(Panel $panel): Panel
     {
         return $panel
-            ->default()
+            // ->default()
             ->id('admin')
             ->path('admin')
-            ->login()
+            // ->login()
             ->darkMode(false)
             ->colors([
                 'primary' => Color::Amber,

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -8,10 +8,20 @@ use Filament\Widgets;
 use Filament\PanelProvider;
 use Filament\Support\Colors\Color;
 use Filament\View\PanelsRenderHook;
+use App\Http\Middleware\CheckIfAdmin;
+use Filament\Navigation\NavigationItem;
+use Filament\Navigation\NavigationGroup;
 use Filament\Http\Middleware\Authenticate;
+use Filament\Navigation\NavigationBuilder;
+use App\Filament\Admin\Resources\TagResource;
+use App\Filament\Admin\Resources\TeamResource;
+use App\Filament\Admin\Resources\UserResource;
 use Illuminate\Session\Middleware\StartSession;
 use Tio\Laravel\Middleware\SetLocaleMiddleware;
 use Illuminate\Cookie\Middleware\EncryptCookies;
+use App\Filament\Admin\Resources\CountryResource;
+use App\Filament\Admin\Resources\LanguageResource;
+use App\Filament\Admin\Resources\StudyCaseResource;
 use Illuminate\Routing\Middleware\SubstituteBindings;
 use Illuminate\Session\Middleware\AuthenticateSession;
 use Illuminate\View\Middleware\ShareErrorsFromSession;
@@ -19,6 +29,8 @@ use Filament\Http\Middleware\DisableBladeIconComponents;
 use Filament\Http\Middleware\DispatchServingFilamentEvent;
 use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken;
 use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
+use Althinect\FilamentSpatieRolesPermissions\Resources\RoleResource;
+use Althinect\FilamentSpatieRolesPermissions\Resources\PermissionResource;
 use Althinect\FilamentSpatieRolesPermissions\FilamentSpatieRolesPermissionsPlugin;
 
 class AdminPanelProvider extends PanelProvider
@@ -30,6 +42,7 @@ class AdminPanelProvider extends PanelProvider
             ->id('admin')
             ->path('admin')
             ->login()
+            ->darkMode(false)
             ->colors([
                 'primary' => Color::Amber,
             ])
@@ -57,6 +70,34 @@ class AdminPanelProvider extends PanelProvider
             ])
             ->authMiddleware([
                 Authenticate::class,
-            ]);
+                CheckIfAdmin::class,
+            ])
+            // ->navigation(function (NavigationBuilder $builder): NavigationBuilder {
+            //     return $builder->items([
+            //         NavigationItem::make('Return to Front-end')
+            //             ->url(url('/app'))
+            //             ->icon('heroicon-o-arrow-left'),
+            //         ...StudyCaseResource::getNavigationItems(),
+            //     ])
+            //         ->groups([
+            //             NavigationGroup::make('Teams and Users')
+            //                 ->items([
+            //                     ...TeamResource::getNavigationItems(),
+            //                     ...UserResource::getNavigationItems(),
+            //                 ]),
+            //             NavigationGroup::make('Roles and Permissions')
+            //                 ->items([
+            //                     ...RoleResource::getNavigationItems(),
+            //                     ...PermissionResource::getNavigationItems(),
+            //                 ]),
+            //             NavigationGroup::make('Definitions')
+            //                 ->items([
+            //                     ...TagResource::getNavigationItems(),
+            //                     ...LanguageResource::getNavigationItems(),
+            //                     ...CountryResource::getNavigationItems(),
+            //                 ]),
+            //         ]);
+            // })
+        ;
     }
 }

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -72,32 +72,42 @@ class AdminPanelProvider extends PanelProvider
                 Authenticate::class,
                 CheckIfAdmin::class,
             ])
-            // ->navigation(function (NavigationBuilder $builder): NavigationBuilder {
-            //     return $builder->items([
-            //         NavigationItem::make('Return to Front-end')
-            //             ->url(url('/app'))
-            //             ->icon('heroicon-o-arrow-left'),
-            //         ...StudyCaseResource::getNavigationItems(),
-            //     ])
-            //         ->groups([
-            //             NavigationGroup::make('Teams and Users')
-            //                 ->items([
-            //                     ...TeamResource::getNavigationItems(),
-            //                     ...UserResource::getNavigationItems(),
-            //                 ]),
-            //             NavigationGroup::make('Roles and Permissions')
-            //                 ->items([
-            //                     ...RoleResource::getNavigationItems(),
-            //                     ...PermissionResource::getNavigationItems(),
-            //                 ]),
-            //             NavigationGroup::make('Definitions')
-            //                 ->items([
-            //                     ...TagResource::getNavigationItems(),
-            //                     ...LanguageResource::getNavigationItems(),
-            //                     ...CountryResource::getNavigationItems(),
-            //                 ]),
-            //         ]);
-            // })
+            ->navigation(function (NavigationBuilder $builder): NavigationBuilder {
+                return $builder->items([
+                    ...StudyCaseResource::getNavigationItems(),
+                ])
+                    ->groups([
+                        NavigationGroup::make('Teams and Users')
+                            ->label(t('Teams and Users'))
+                            ->items([
+                                ...TeamResource::getNavigationItems(),
+                                ...UserResource::getNavigationItems(),
+                            ]),
+                        NavigationGroup::make('Roles and Permissions')
+                            ->label(t('Roles and Permissions'))
+                            ->items([
+                                ...RoleResource::getNavigationItems(),
+                                ...PermissionResource::getNavigationItems(),
+                            ]),
+                        NavigationGroup::make('Definitions')
+                            ->label(t('Definitions'))
+                            ->items([
+                                ...TagResource::getNavigationItems(),
+                                ...LanguageResource::getNavigationItems(),
+                                ...CountryResource::getNavigationItems(),
+                            ]),
+                        // create a navigation group without label, nothing will be showed for non admin user
+                        NavigationGroup::make('')
+                            ->items([
+                                // Return to Front-end item cannot be the first item, otherwise user will be redirected to app panel when visiting admin panel
+                                NavigationItem::make('Return to Front-end')
+                                    ->label(t('Return to Front-end'))
+                                    ->url(url('/app'))
+                                    ->icon('heroicon-o-arrow-left')
+                                    ->visible(fn() => auth()->user()?->can('access admin panel')),
+                            ]),
+                    ]);
+            })
         ;
     }
 }

--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -34,6 +34,7 @@ class AppPanelProvider extends PanelProvider
     public function panel(Panel $panel): Panel
     {
         return $panel
+            ->default()
             ->id('app')
             ->path('app')
             ->tenant(Team::class)
@@ -74,6 +75,15 @@ class AppPanelProvider extends PanelProvider
             ->authMiddleware([
                 Authenticate::class,
             ])
+
+            // if below code segment is commented, user can enter app panel and admin panel via direct URL successfully:
+            // http://aef.test/app
+            // http://aef.test/admin
+            //
+            // if below code segment is commented (no need to uncomment similar code segment in AdminPanelProvider.php),
+            // once user visited admin panel, user will always be redirected to admin panel when visiting app panel...
+            // not quite sure how to trace which custom class and/or middleware class is related...
+
             // ->navigation(function (NavigationBuilder $builder): NavigationBuilder {
             //     return $builder->items([
             //         NavigationItem::make('Admin Panel')

--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -9,12 +9,17 @@ use Filament\Widgets;
 use Filament\PanelProvider;
 use Filament\Support\Colors\Color;
 use Filament\View\PanelsRenderHook;
+use Filament\Navigation\NavigationItem;
 use App\Filament\App\Pages\RegisterTeam;
+use Filament\Navigation\NavigationGroup;
 use Filament\Http\Middleware\Authenticate;
+use Filament\Navigation\NavigationBuilder;
 use Illuminate\Session\Middleware\StartSession;
 use Tio\Laravel\Middleware\SetLocaleMiddleware;
 use App\Http\Middleware\SetLatestTeamMiddleware;
 use Illuminate\Cookie\Middleware\EncryptCookies;
+use App\Filament\App\Resources\StudyCaseResource;
+use App\Filament\App\Resources\OrganisationResource;
 use Illuminate\Routing\Middleware\SubstituteBindings;
 use Illuminate\Session\Middleware\AuthenticateSession;
 use Illuminate\View\Middleware\ShareErrorsFromSession;
@@ -68,6 +73,22 @@ class AppPanelProvider extends PanelProvider
             ])
             ->authMiddleware([
                 Authenticate::class,
-            ]);
+            ])
+            // ->navigation(function (NavigationBuilder $builder): NavigationBuilder {
+            //     return $builder->items([
+            //         NavigationItem::make('Admin Panel')
+            //             ->url('/admin')
+            //             ->icon('heroicon-o-adjustments-horizontal')
+            //             ->visible(fn() => auth()->user()?->can('access admin panel')),
+            //         ...StudyCaseResource::getNavigationItems(),
+            //     ])
+            //         ->groups([
+            //             NavigationGroup::make('Definitions')
+            //                 ->items([
+            //                     ...OrganisationResource::getNavigationItems(),
+            //                 ]),
+            //         ]);
+            // })
+        ;
     }
 }

--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -76,29 +76,28 @@ class AppPanelProvider extends PanelProvider
                 Authenticate::class,
             ])
 
-            // if below code segment is commented, user can enter app panel and admin panel via direct URL successfully:
-            // http://aef.test/app
-            // http://aef.test/admin
-            //
-            // if below code segment is commented (no need to uncomment similar code segment in AdminPanelProvider.php),
-            // once user visited admin panel, user will always be redirected to admin panel when visiting app panel...
-            // not quite sure how to trace which custom class and/or middleware class is related...
-
-            // ->navigation(function (NavigationBuilder $builder): NavigationBuilder {
-            //     return $builder->items([
-            //         NavigationItem::make('Admin Panel')
-            //             ->url('/admin')
-            //             ->icon('heroicon-o-adjustments-horizontal')
-            //             ->visible(fn() => auth()->user()?->can('access admin panel')),
-            //         ...StudyCaseResource::getNavigationItems(),
-            //     ])
-            //         ->groups([
-            //             NavigationGroup::make('Definitions')
-            //                 ->items([
-            //                     ...OrganisationResource::getNavigationItems(),
-            //                 ]),
-            //         ]);
-            // })
+            ->navigation(function (NavigationBuilder $builder): NavigationBuilder {
+                return $builder->items([
+                    ...StudyCaseResource::getNavigationItems(),
+                ])
+                    ->groups([
+                        NavigationGroup::make('Definitions')
+                            ->label(t('Definitions'))
+                            ->items([
+                                ...OrganisationResource::getNavigationItems(),
+                            ]),
+                        // create a navigation group without label, nothing will be showed for non admin user
+                        NavigationGroup::make('')
+                            ->items([
+                                // Admin panel item cannot be the first item, otherwise user will be redirected to admin panel when visiting app panel
+                                NavigationItem::make('Admin Panel')
+                                    ->label(t('Admin Panel'))
+                                    ->url('/admin')
+                                    ->icon('heroicon-o-adjustments-horizontal')
+                                    ->visible(fn() => auth()->user()?->can('access admin panel')),
+                            ]),
+                    ]);
+            })
         ;
     }
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,6 +7,10 @@ Route::get('/', static function () {
     return redirect('/app');
 });
 
+Route::get('/login', static function () {
+    return redirect('/app/login');
+})->name('login');
+
 Route::get('register', Register::class)
     ->name('filament.app.register')
     ->middleware('signed');


### PR DESCRIPTION
Hi @dave-mills , I need your advice.

I tried to copy "Admin button" related code from tape-data-system.

The related code is to create a customised sidebar with navigation groups and navigation items.

Before using this code, I can enter app panel and admin panel successfully with direct url in browser.
After using this code in AppPanelProvider.php, once I go to admin panel, I will always redirected to admin panel when I access app panel.

I did a careful comparison on AppPanelProvider.php and AdminPanelProvider.php between tape-data-system and aef. However I am not able to find any clue...

I am not quite sure how to trace which custom class and/or middleware class is related...

Many Thanks.