### PR TITLE
Increase File Upload Size Limitation From 25 MB To 50 MB

### DIFF
--- a/app/Filament/Admin/Resources/TeamResource.php
+++ b/app/Filament/Admin/Resources/TeamResource.php
@@ -44,7 +44,7 @@ class TeamResource extends Resource
                             ->downloadable()
                             ->preserveFilenames()
                             ->maxFiles(1)
-                            ->maxSize(25600)
+                            ->maxSize(51200)
                             ->columnSpanFull()
                             ->image()
                             ->disk('s3'),

--- a/app/Filament/App/Resources/ClaimResource/RelationManagers/EvidencesRelationManager.php
+++ b/app/Filament/App/Resources/ClaimResource/RelationManagers/EvidencesRelationManager.php
@@ -56,7 +56,7 @@ class EvidencesRelationManager extends RelationManager
                             ->collection('evidence')
                             ->preserveFilenames()
                             ->downloadable()
-                            ->maxSize(25600)
+                            ->maxSize(51200)
                             ->disk('s3'),
 
                     ])

--- a/app/Filament/App/Resources/OrganisationResource.php
+++ b/app/Filament/App/Resources/OrganisationResource.php
@@ -54,7 +54,7 @@ class OrganisationResource extends Resource
                     ->downloadable()
                     ->preserveFilenames()
                     ->maxFiles(1)
-                    ->maxSize(25600)
+                    ->maxSize(51200)
                     ->columnSpanFull()
                     ->image()
                     ->disk('s3'),

--- a/app/Filament/App/Resources/StudyCaseResource.php
+++ b/app/Filament/App/Resources/StudyCaseResource.php
@@ -278,7 +278,7 @@ class StudyCaseResource extends Resource
                                             ->collection('comms_products')
                                             ->preserveFilenames()
                                             ->downloadable()
-                                            ->maxSize(25600)
+                                            ->maxSize(51200)
                                             ->disk('s3'),
 
                                     ])
@@ -301,7 +301,7 @@ class StudyCaseResource extends Resource
                                     ->downloadable()
                                     ->preserveFilenames()
                                     ->maxFiles(1)
-                                    ->maxSize(25600)
+                                    ->maxSize(51200)
                                     ->columnSpanFull()
                                     ->image()
                                     ->imageEditor()
@@ -315,7 +315,7 @@ class StudyCaseResource extends Resource
                                     ->downloadable()
                                     ->preserveFilenames()
                                     ->maxFiles(1)
-                                    ->maxSize(25600)
+                                    ->maxSize(51200)
                                     ->columnSpanFull()
                                     ->image()
                                     ->disk('s3'),
@@ -337,7 +337,7 @@ class StudyCaseResource extends Resource
                                             ->preserveFilenames()
                                             ->downloadable()
                                             ->required()
-                                            ->maxSize(25600)
+                                            ->maxSize(51200)
                                             ->image()
                                             ->disk('s3'),
 

--- a/config/media-library.php
+++ b/config/media-library.php
@@ -12,7 +12,7 @@ return [
      * The maximum file size of an item in bytes.
      * Adding a larger file will result in an exception.
      */
-    'max_file_size' => 1024 * 1024 * 25, // 25MB
+    'max_file_size' => 1024 * 1024 * 50, // 50MB
 
     /*
      * This queue connection will be used to generate derived and responsive images.


### PR DESCRIPTION
This PR is submitted to fix #59 

This PR contains below changes:
1. spatie media library config file, change file upload size limitation from 25 MB to 50 MB
2. SpatieMediaLibraryFileUpload->maxSize(), change from 25600 to 51200 (in KB)