### PR TITLE
separates embedded youtube video from url

### DIFF
--- a/app/Filament/App/Resources/StudyCaseResource.php
+++ b/app/Filament/App/Resources/StudyCaseResource.php
@@ -269,10 +269,13 @@ class StudyCaseResource extends Resource
 
                                         TextInput::make('url')
                                             ->label(t('URL'))
-                                            // Note: as <iframe> may be entered here to include a Youtube video, do not enforce to enter a valid URL
-                                            // ->url()
+                                            ->url()
                                             ->maxLength(65535),
 
+                                        TextInput::make('youtube_id')
+                                            ->label(t('Youtube ID'))
+                                            ->hint(t('To enbed a youtube video, add the id. On YouTube, when you hit "share", the id is the random-like string after https://youtu.be/')),
+            
                                         Forms\Components\SpatieMediaLibraryFileUpload::make('file')
                                             ->label(t('File'))
                                             ->collection('comms_products')

--- a/database/migrations/2024_11_12_113356_add_youtube_id_on_communication_products_table.php
+++ b/database/migrations/2024_11_12_113356_add_youtube_id_on_communication_products_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('communication_products', function (Blueprint $table) {
+            $table->text('youtube_id')->nullable()->after('url');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        //
+    }
+};

--- a/resources/views/cases/products.blade.php
+++ b/resources/views/cases/products.blade.php
@@ -20,7 +20,6 @@
                 $file_url = $media->getUrl();
                 $file_type = basename($media->mime_type);
             }
-            $contains_iframe = strpos($communicationProduct->url, '<iframe') !== false;
         @endphp
 
         <div class="pt-8 pb-2 mt-4 flex items-start">
@@ -42,26 +41,29 @@
                 @endif
                 <!-- Visit Link Button -->
                 @if($communicationProduct->url)
-                    @if(!$contains_iframe)
-                        <a href="{{ $communicationProduct->url }}" target="_blank" class="bg-ochre hover-effect text-white rounded-lg px-8 py-2 h-12 flex items-center">
-                        <svg xmlns="https://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-8 w-8 mr-8">
-                                            <path stroke-linecap="round" stroke-linejoin="round" d="M13.19 8.688a4.5 4.5 0 0 1 1.242 7.244l-4.5 4.5a4.5 4.5 0 0 1-6.364-6.364l1.757-1.757m13.35-.622 1.757-1.757a4.5 4.5 0 0 0-6.364-6.364l-4.5 4.5a4.5 4.5 0 0 0 1.242 7.244" />
-                                        </svg>
-                            Visit link
-                        </a>
-                    @endif
+                    <a href="{{ $communicationProduct->url }}" target="_blank" class="bg-ochre hover-effect text-white rounded-lg px-8 py-2 h-12 flex items-center">
+                    <svg xmlns="https://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-8 w-8 mr-8">
+                                        <path stroke-linecap="round" stroke-linejoin="round" d="M13.19 8.688a4.5 4.5 0 0 1 1.242 7.244l-4.5 4.5a4.5 4.5 0 0 1-6.364-6.364l1.757-1.757m13.35-.622 1.757-1.757a4.5 4.5 0 0 0-6.364-6.364l-4.5 4.5a4.5 4.5 0 0 0 1.242 7.244" />
+                                    </svg>
+                        Visit link
+                    </a>
                 @endif
             </div>
         </div>
 
         <!-- Embedded Youtube Video -->
         <div class="pb-8">
-            @if($communicationProduct->url)
-                @if($contains_iframe)
-                    <div class="iframe-container items-center mt-8">
-                        {!! $communicationProduct->url !!}
-                    </div>
-                @endif
+            @if($communicationProduct->youtube_id)
+                <div class="iframe-container items-center mt-8">
+                    <iframe
+                        width="560"
+                        height="315"
+                        src="https://www.youtube.com/embed/{{ $communicationProduct->youtube_id }}"
+                        frameborder="0"
+                        allow="accelerometer; encrypted-media; gyroscope; picture-in-picture"
+                        allowfullscreen
+                    ></iframe>
+                </div>
             @endif
         </div>
 


### PR DESCRIPTION
This PR adds a dedicated field for users to enter the YouTube video ID if they want it embedded on the frontend case page. It now follows a similar setup to the Stats4SD resources site.