### PR TITLE
Trim URL Content When Textbox Lost Focus

### DIFF
--- a/app/Filament/Admin/Resources/TeamResource.php
+++ b/app/Filament/Admin/Resources/TeamResource.php
@@ -2,21 +2,22 @@
 
 namespace App\Filament\Admin\Resources;
 
+use Filament\Forms;
+use App\Models\Team;
+use Filament\Tables;
+use Filament\Forms\Form;
+use Filament\Tables\Table;
+use Illuminate\Support\Str;
+use Filament\Infolists\Infolist;
+use Filament\Resources\Resource;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Columns\ImageColumn;
+use Filament\Infolists\Components\Section;
+use Filament\Infolists\Components\TextEntry;
+use Filament\Infolists\Components\ViewEntry;
 use App\Filament\Admin\Resources\TeamResource\Pages;
 use App\Filament\Admin\Resources\TeamResource\RelationManagers\UsersRelationManager;
 use App\Filament\Admin\Resources\TeamResource\RelationManagers\InvitesRelationManager;
-use App\Models\Team;
-use Filament\Infolists\Components\TextEntry;
-use Filament\Infolists\Infolist;
-use Filament\Tables\Columns\ImageColumn;
-use Filament\Tables\Columns\TextColumn;
-use Filament\Tables;
-use Filament\Tables\Table;
-use Filament\Forms;
-use Filament\Forms\Form;
-use Filament\Infolists\Components\Section;
-use Filament\Infolists\Components\ViewEntry;
-use Filament\Resources\Resource;
 
 class TeamResource extends Resource
 {
@@ -34,8 +35,13 @@ class TeamResource extends Resource
                             ->required()
                             ->maxLength(255),
                         Forms\Components\TextInput::make('website')
-                            // ->url()
-                            ->maxLength(255),
+                            ->url()
+                            ->maxLength(255)
+                            ->live(onBlur: true)
+                            ->afterStateUpdated(function (Forms\Set $set, Forms\Get $get) {
+                                static::trimUrlContent($set, $get, 'website');
+                            }),
+
                         Forms\Components\Textarea::make('description'),
                         Forms\Components\SpatieMediaLibraryFileUpload::make('logo')
                             ->label(t('Logo'))
@@ -107,5 +113,16 @@ class TeamResource extends Resource
             ->schema([
                 TextEntry::make('description')->hiddenLabel(),
             ]);
+    }
+
+    protected static function trimUrlContent(Forms\Set $set, Forms\Get $get, string $fieldName): void
+    {
+        $fieldValue = $get($fieldName);
+
+        if (! $fieldValue) {
+            return;
+        }
+
+        $set($fieldName, Str::trim($fieldValue));
     }
 }

--- a/app/Filament/App/Resources/ClaimResource/RelationManagers/EvidencesRelationManager.php
+++ b/app/Filament/App/Resources/ClaimResource/RelationManagers/EvidencesRelationManager.php
@@ -6,6 +6,7 @@ use Filament\Forms;
 use Filament\Tables;
 use Filament\Forms\Form;
 use Filament\Tables\Table;
+use Illuminate\Support\Str;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\SoftDeletingScope;
@@ -48,8 +49,12 @@ class EvidencesRelationManager extends RelationManager
 
                         Forms\Components\TextInput::make('url')
                             ->label(t('URL'))
-                            // ->url()
-                            ->maxLength(65535),
+                            ->url()
+                            ->maxLength(65535)
+                            ->live(onBlur: true)
+                            ->afterStateUpdated(function (Forms\Set $set, Forms\Get $get) {
+                                static::trimUrlContent($set, $get, 'url');
+                            }),
 
                         Forms\Components\SpatieMediaLibraryFileUpload::make('file')
                             ->label(t('File'))
@@ -125,5 +130,16 @@ class EvidencesRelationManager extends RelationManager
                     Tables\Actions\DeleteBulkAction::make(),
                 ]),
             ]);
+    }
+
+    protected static function trimUrlContent(Forms\Set $set, Forms\Get $get, string $fieldName): void
+    {
+        $fieldValue = $get($fieldName);
+
+        if (! $fieldValue) {
+            return;
+        }
+
+        $set($fieldName, Str::trim($fieldValue));
     }
 }

--- a/app/Filament/App/Resources/OrganisationResource.php
+++ b/app/Filament/App/Resources/OrganisationResource.php
@@ -2,16 +2,17 @@
 
 namespace App\Filament\App\Resources;
 
-use App\Filament\App\Resources\OrganisationResource\Pages;
-use App\Filament\App\Resources\OrganisationResource\RelationManagers;
-use App\Models\Organisation;
 use Filament\Forms;
-use Filament\Forms\Form;
-use Filament\Resources\Resource;
 use Filament\Tables;
+use Filament\Forms\Form;
 use Filament\Tables\Table;
+use Illuminate\Support\Str;
+use App\Models\Organisation;
+use Filament\Resources\Resource;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\SoftDeletingScope;
+use App\Filament\App\Resources\OrganisationResource\Pages;
+use App\Filament\App\Resources\OrganisationResource\RelationManagers;
 
 class OrganisationResource extends Resource
 {
@@ -45,8 +46,12 @@ class OrganisationResource extends Resource
                     ->maxLength(255),
                 Forms\Components\TextInput::make('website')
                     ->label(t('Website'))
-                    // ->url()
-                    ->maxLength(255),
+                    ->url()
+                    ->maxLength(255)
+                    ->live(onBlur: true)
+                    ->afterStateUpdated(function (Forms\Set $set, Forms\Get $get) {
+                        static::trimUrlContent($set, $get, 'website');
+                    }),
                 Forms\Components\SpatieMediaLibraryFileUpload::make('logo')
                     ->label(t('Logo'))
                     ->hint(t('Please upload organisation logo image.'))
@@ -110,5 +115,16 @@ class OrganisationResource extends Resource
             'create' => Pages\CreateOrganisation::route('/create'),
             'edit' => Pages\EditOrganisation::route('/{record}/edit'),
         ];
+    }
+
+    protected static function trimUrlContent(Forms\Set $set, Forms\Get $get, string $fieldName): void
+    {
+        $fieldValue = $get($fieldName);
+
+        if (! $fieldValue) {
+            return;
+        }
+
+        $set($fieldName, Str::trim($fieldValue));
     }
 }

--- a/app/Filament/App/Resources/StudyCaseResource.php
+++ b/app/Filament/App/Resources/StudyCaseResource.php
@@ -7,17 +7,12 @@ use Filament\Tables;
 use Filament\Forms\Form;
 use App\Models\StudyCase;
 use Filament\Tables\Table;
-use App\Models\Organisation;
-use Filament\Facades\Filament;
+use Illuminate\Support\Str;
 use Filament\Resources\Resource;
 use Filament\Forms\Components\Tabs;
-use Illuminate\Support\Facades\Auth;
 use Filament\Forms\Components\Section;
 use Filament\Forms\Components\TextInput;
-use Illuminate\Database\Eloquent\Builder;
 use Filament\Forms\Components\Placeholder;
-use Filament\Forms\Components\Builder\Block;
-use Illuminate\Database\Eloquent\SoftDeletingScope;
 use App\Filament\App\Resources\StudyCaseResource\Pages;
 use App\Filament\App\Resources\StudyCaseResource\RelationManagers;
 
@@ -138,8 +133,12 @@ class StudyCaseResource extends Resource
                                                     ->maxLength(255),
                                                 Forms\Components\TextInput::make('website')
                                                     ->label(t('Website'))
-                                                    // ->url()
-                                                    ->maxLength(255),
+                                                    ->url()
+                                                    ->maxLength(255)
+                                                    ->live(onBlur: true)
+                                                    ->afterStateUpdated(function (Forms\Set $set, Forms\Get $get) {
+                                                        static::trimUrlContent($set, $get, 'website');
+                                                    }),
                                                 Forms\Components\Textarea::make('note')
                                                     ->label(t('Note'))
                                                     ->maxLength(65535)
@@ -269,8 +268,12 @@ class StudyCaseResource extends Resource
 
                                         TextInput::make('url')
                                             ->label(t('URL'))
-                                            // ->url()
-                                            ->maxLength(65535),
+                                            ->url()
+                                            ->maxLength(65535)
+                                            ->live(onBlur: true)
+                                            ->afterStateUpdated(function (Forms\Set $set, Forms\Get $get) {
+                                                static::trimUrlContent($set, $get, 'url');
+                                            }),
 
                                         TextInput::make('youtube_id')
                                             ->label(t('Youtube ID'))
@@ -453,5 +456,16 @@ class StudyCaseResource extends Resource
             'edit' => Pages\EditStudyCase::route('/{record}/edit'),
             'view' => Pages\ViewStudyCase::route('/{record}'),
         ];
+    }
+
+    protected static function trimUrlContent(Forms\Set $set, Forms\Get $get, string $fieldName): void
+    {
+        $fieldValue = $get($fieldName);
+
+        if (! $fieldValue) {
+            return;
+        }
+
+        $set($fieldName, Str::trim($fieldValue));
     }
 }


### PR DESCRIPTION
This PR is submitted for fix #71 

It contains below changes:
1. After entering or pasting URL into textbox, trim the content when textbox lost focus