### PR TITLE
Catalogue updates

### DIFF
--- a/app/Filament/Admin/Resources/ClaimResource/Pages/EditClaim.php
+++ b/app/Filament/Admin/Resources/ClaimResource/Pages/EditClaim.php
@@ -17,6 +17,25 @@ class EditClaim extends EditRecord
         ];
     }
 
+    public function getBreadcrumbs(): array
+    {
+        $breadcrumbs = [];
+        $studyCase = $this->record->studyCase;
+
+        $casesUrl = route('filament.admin.resources.study-cases.index');
+        $breadcrumbs[$casesUrl] = 'Cases';
+
+        $studyCaseEditUrl = route('filament.admin.resources.study-cases.edit', ['record' => $studyCase->id]);
+        $breadcrumbs[$studyCaseEditUrl] = $studyCase->title;
+    
+        $claimsUrl = $studyCaseEditUrl . '?tab=-tab-1-tab&activeRelationManager=0';
+        $breadcrumbs[$claimsUrl] = 'Claims';
+
+        $breadcrumbs[] = 'Edit';
+
+        return $breadcrumbs;
+    }
+
     // redirect to Study case edit view, tab "Claims and Evidence" after record update
     protected function getRedirectUrl(): string
     {

--- a/app/Filament/App/Resources/ClaimResource/Pages/EditClaim.php
+++ b/app/Filament/App/Resources/ClaimResource/Pages/EditClaim.php
@@ -18,18 +18,29 @@ class EditClaim extends EditRecord
         ];
     }
 
-    // Remove bread crumb "Claims > Edit" to avoid user clicks "Claims" link to list all claims records of all cases.
-    //
-    // By setting an empty string as title, below items will not be showed:
-    // 1. Bread crumb "Claims > Edit"
-    // 2. Page title "Edit Claim"
-    // 3. "Delete" button in page header
-    //
-    // P.S. The only way to delete a claim record: Cases resource > Claims relation manager table
-
-    public function getTitle(): string | Htmlable
+    public function getBreadcrumbs(): array
     {
-        return '';
+        $breadcrumbs = [];
+        $studyCase = $this->record->studyCase;
+        $latestTeamId = auth()->user()->latestTeam->id;
+
+        $casesUrl = route('filament.app.resources.study-cases.index', [
+            'tenant' => $latestTeamId,
+        ]);
+        $breadcrumbs[$casesUrl] = 'Cases';
+
+        $studyCaseEditUrl = route('filament.app.resources.study-cases.edit', [
+            'tenant' => $latestTeamId,
+            'record' => $studyCase->id,
+        ]);
+        $breadcrumbs[$studyCaseEditUrl] = $studyCase->title;
+    
+        $claimsUrl = $studyCaseEditUrl . '?tab=-tab-1-tab&activeRelationManager=0';
+        $breadcrumbs[$claimsUrl] = 'Claims';
+
+        $breadcrumbs[] = 'Edit';
+
+        return $breadcrumbs;
     }
 
     // redirect to Study case edit view, tab "Claims and Evidence" after record update

--- a/app/Filament/App/Resources/ClaimResource/RelationManagers/EvidencesRelationManager.php
+++ b/app/Filament/App/Resources/ClaimResource/RelationManagers/EvidencesRelationManager.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\App\Resources\ClaimResource\RelationManagers;
 
+use Filament\Forms\Get;
 use Filament\Forms;
 use Filament\Tables;
 use Filament\Forms\Form;
@@ -42,6 +43,11 @@ class EvidencesRelationManager extends RelationManager
                     ->relationship()
                     ->schema([
 
+                        Forms\Components\Checkbox::make('is_communication_product')
+                            ->label(t('Has this source already been added in the communication products section?'))
+                            ->live()
+                            ->inline(false),
+                            
                         Forms\Components\TextInput::make('description')
                             ->label(t('Description'))
                             ->required()
@@ -54,7 +60,8 @@ class EvidencesRelationManager extends RelationManager
                             ->live(onBlur: true)
                             ->afterStateUpdated(function (Forms\Set $set, Forms\Get $get) {
                                 static::trimUrlContent($set, $get, 'url');
-                            }),
+                            })
+                            ->visible(fn (Get $get) => $get('is_communication_product') === false),
 
                         Forms\Components\SpatieMediaLibraryFileUpload::make('file')
                             ->label(t('File'))
@@ -62,8 +69,8 @@ class EvidencesRelationManager extends RelationManager
                             ->preserveFilenames()
                             ->downloadable()
                             ->maxSize(512000)
-                            ->disk('s3'),
-
+                            ->disk('s3')
+                            ->visible(fn (Get $get) => $get('is_communication_product') === false),
                     ])
                     ->defaultItems(1)
                     ->addActionLabel(t('Add another source'))

--- a/app/Filament/App/Resources/StudyCaseResource.php
+++ b/app/Filament/App/Resources/StudyCaseResource.php
@@ -242,11 +242,6 @@ class StudyCaseResource extends Resource
                                         'undo',
                                         'redo',
                                     ]),
-
-                                Forms\Components\Textarea::make('note')
-                                    ->label(t('Note'))
-                                    ->maxLength(65535)
-                                    ->columnSpanFull(),
                             ]),
 
                         Tabs\Tab::make('tab-3')

--- a/database/migrations/2025_01_08_182405_add_is_communication_product_to_evidence_attachments_table.php
+++ b/database/migrations/2025_01_08_182405_add_is_communication_product_to_evidence_attachments_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('evidence_attachments', function (Blueprint $table) {
+            $table->boolean('is_communication_product')->default(false)->after('evidence_id');
+
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('evidence_attachments', function (Blueprint $table) {
+            //
+        });
+    }
+};

--- a/database/migrations/2025_01_10_111006_remove_note_from_study_cases_table.php
+++ b/database/migrations/2025_01_10_111006_remove_note_from_study_cases_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('study_cases', function (Blueprint $table) {
+            $table->dropColumn('note');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('study_cases', function (Blueprint $table) {
+            //
+        });
+    }
+};

--- a/resources/views/cases/claims.blade.php
+++ b/resources/views/cases/claims.blade.php
@@ -15,7 +15,7 @@
         <!-- Claim Header -->
         <div class="mb-4">
             <div class="text-2xl text-dark-teal font-bold border-l-4 border-dark-teal pl-4">
-                {{ mb_strtoupper($claim->claim_statement, 'UTF-8') }}
+                {{ $claim->claim_statement }}
             </div>
 
             <!-- Evidence -->
@@ -39,21 +39,27 @@
                                 <div class="pt-6">
                                     {{ $evidenceAttachment->description }}
                                 </div>
-                                @if($evidenceAttachment->url)
-                                    <div class="text-ochre pt-2 flex items-center">
-                                        <svg xmlns="https://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-6 w-6 mr-2">
-                                            <path stroke-linecap="round" stroke-linejoin="round" d="M13.19 8.688a4.5 4.5 0 0 1 1.242 7.244l-4.5 4.5a4.5 4.5 0 0 1-6.364-6.364l1.757-1.757m13.35-.622 1.757-1.757a4.5 4.5 0 0 0-6.364-6.364l-4.5 4.5a4.5 4.5 0 0 0 1.242 7.244" />
+                                @if($evidenceAttachment->is_communication_product===1)
+                                    <div class="pt-2 flex items-center">
+                                        See section  &nbsp;<a href="#case-products" class="text-ochre"> Communication products</a> &nbsp;for source details
+                                    </div>
+                                @else
+                                    @if($evidenceAttachment->url)
+                                        <div class="text-ochre pt-2 flex items-center">
+                                            <svg xmlns="https://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-6 w-6 mr-2">
+                                                <path stroke-linecap="round" stroke-linejoin="round" d="M13.19 8.688a4.5 4.5 0 0 1 1.242 7.244l-4.5 4.5a4.5 4.5 0 0 1-6.364-6.364l1.757-1.757m13.35-.622 1.757-1.757a4.5 4.5 0 0 0-6.364-6.364l-4.5 4.5a4.5 4.5 0 0 0 1.242 7.244" />
+                                            </svg>
+                                            <a href="{{ $evidenceAttachment->url }}" class="text-ochre hover:underline" target="_blank">{{ $evidenceAttachment->url }}</a>
+                                        </div>
+                                    @endif
+                                    @if($evidenceAttachment->getMedia('evidence')->first())
+                                        <div class="text-ochre pt-2 flex items-center">
+                                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-6 w-6 mr-2">
+                                            <path stroke-linecap="round" stroke-linejoin="round" d="m9 12.75 3 3m0 0 3-3m-3 3v-7.5M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
                                         </svg>
-                                        <a href="{{ $evidenceAttachment->url }}" class="text-ochre hover:underline" target="_blank">{{ $evidenceAttachment->url }}</a>
-                                    </div>
-                                @endif
-                                @if($evidenceAttachment->getMedia('evidence')->first())
-                                    <div class="text-ochre pt-2 flex items-center">
-                                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-6 w-6 mr-2">
-                                        <path stroke-linecap="round" stroke-linejoin="round" d="m9 12.75 3 3m0 0 3-3m-3 3v-7.5M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
-                                    </svg>
-                                        <a href="{{ $evidenceAttachment->getMedia('evidence')->first()->getUrl() }}" class="text-ochre hover:underline" target="_blank">{{ $evidenceAttachment->getMedia('evidence')->first()->file_name }} | {{ round($evidenceAttachment->getMedia('evidence')->first()->size/1000,0) }}MB</a>
-                                    </div>
+                                            <a href="{{ $evidenceAttachment->getMedia('evidence')->first()->getUrl() }}" class="text-ochre hover:underline" target="_blank">{{ $evidenceAttachment->getMedia('evidence')->first()->file_name }} | {{ round($evidenceAttachment->getMedia('evidence')->first()->size/1000,0) }}MB</a>
+                                        </div>
+                                    @endif
                                 @endif
                             @endforeach
                         </div>

--- a/resources/views/cases/details.blade.php
+++ b/resources/views/cases/details.blade.php
@@ -10,13 +10,11 @@
 
     <div class="py-6">
         <h1 class="text-xl font-bold pb-1">STATEMENT</h1>
-        <h2 class="text-lg font-bold text-mint pb-4">What the case argues, framed as a hypothesis: "if the target audience does X then Y will happen".</h2>
         <div class="prose">{!! $studycase->statement !!}</div>
     </div>
 
     <div class="py-6">
         <h1 class="text-xl font-bold pb-1">TARGET AUDIENCE</h1>
-        <h2 class="text-lg font-bold text-mint pb-4">Who the case aims to persuade.</h2>
         <div class="prose">{!! $studycase->target_audience !!}</div>
     </div>
 
@@ -27,19 +25,16 @@
 
     <div class="py-6">
         <h1 class="text-xl font-bold pb-1">FRAMING OF THE ARGUMENT</h1>
-        <h2 class="text-lg font-bold text-mint pb-4">Background and logic of the case.</h2>
         <div class="prose">{!! $studycase->framing !!}</div>
     </div>
 
     <div class="py-6">
         <h1 class="text-xl font-bold pb-1">STRATEGY</h1>
-        <h2 class="text-lg font-bold text-mint pb-4">How the case is argued.</h2>
         <div class="prose">{!! $studycase->strategy_to_argue !!}</div>
     </div>
 
     <div class="pt-6 pb-10">
         <h1 class="text-xl font-bold pb-1">CALLS TO ACTION</h1>
-        <h2 class="text-lg font-bold text-mint pb-4">Changes or actions the case is trying to persuade the audience to take.</h2>
         <div class="prose">{!! $studycase->call_to_action !!}</div>
     </div>
 </div>

--- a/resources/views/cases/index.blade.php
+++ b/resources/views/cases/index.blade.php
@@ -10,7 +10,7 @@
         <div class="absolute bottom-0 w-full h-1/3 bg-dark-teal-70 flex justify-left">
             <div class="text-left px-12 m-4">
                 <div class="text-3xl text-ochre">CASE</div>
-                <div class="text-3xl text-white font-bold">{{ mb_strtoupper($studycase->title, 'UTF-8') }}</div>
+                <div class="text-3xl text-white font-bold">{{ $studycase->title }}</div>
                 <div class="text-2xl text-white mt-4">{{ $studycase->team->name }}, {{ $studycase->year_of_development }}</div>
             </div>
         </div>
@@ -78,12 +78,17 @@
 
         </div>
 
+        @php
+            $productCount = $studycase->communicationProducts()->count();
+            $productText = $productCount === 1 ? 'Communication product' : 'Communication products';
+        @endphp
+
         <!-- Component Buttons -->
         <div class="flex flex-wrap justify-center items-center gap-4 pt-6">
             <p class="text-dark-teal font-bold mr-4">Jump to...</p>
-            <a href="#case-details" class="text-xl rounded-button hover-effect bg-ochre text-white">Case Details</a>
+            <a href="#case-products" class="text-xl rounded-button hover-effect bg-ochre text-white">{{ $productText }}</a>
+            <a href="#case-details" class="text-xl rounded-button hover-effect bg-ochre text-white">Case details</a>
             <a href="#case-claims" class="text-xl rounded-button hover-effect bg-ochre text-white">Claims and evidence</a>
-            <a href="#case-products" class="text-xl rounded-button hover-effect bg-ochre text-white">The case as presented</a>
             <a href="#case-other-details" class="text-xl rounded-button hover-effect bg-ochre text-white">Other details</a>
         </div>
 
@@ -91,9 +96,9 @@
 
     <div class="py-8 px-12">
         <!-- Include blades for components-->
+        <div id="case-products" class="mt-8">@include('cases.products')</div>
         <div id="case-details" class="mt-4"> @include('cases.details')</div>
         <div id="case-claims" class="mt-8">@include('cases.claims')</div>
-        <div id="case-products" class="mt-8">@include('cases.products')</div>
         <div id="case-other-details" class="my-8">@include('cases.other')</div>
     </div>
 

--- a/resources/views/cases/products.blade.php
+++ b/resources/views/cases/products.blade.php
@@ -1,7 +1,11 @@
 <!-- Header Section -->
 <div class="bg-dark-teal text-white py-6 px-20">
     <div class="flex flex-col items-start">
-        <h1 class="text-2xl font-bold">THE CASE AS PRESENTED</h1>
+        @php
+            $productCount = $studycase->communicationProducts()->count();
+            $productText = $productCount === 1 ? 'Communication product' : 'Communication products';
+        @endphp
+        <h1 class="text-2xl font-bold uppercase">{{ $productText }}</h1>
         <p class="text-lg mt-4">Communication products developed to present the case to the target audience.
                                 These may be videos, presentations, documents or other relevant formats.</p>
     </div>

--- a/resources/views/home/recent-cases.blade.php
+++ b/resources/views/home/recent-cases.blade.php
@@ -25,63 +25,29 @@
                     <!-- Divider -->
                     <div class="h-1 w-full bg-teal my-3"></div>
 
-                    <!-- First Row Metadata-->
-                    <div class="grid grid-cols-1 sm:grid-cols-2 gap-2 mb-4">
-                        <!-- Languages -->
-                        <div class="flex items-start">
-                            <div class="flex-shrink-0 mr-4">
-                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="var(--mint)" class="w-8 h-8 text-gray-600">
-                                    <path stroke-linecap="round" stroke-linejoin="round" d="M12 20.25c4.97 0 9-3.694 9-8.25s-4.03-8.25-9-8.25S3 7.444 3 12c0 2.104.859 4.023 2.273 5.48.432.447.74 1.04.586 1.641a4.483 4.483 0 0 1-.923 1.785A5.969 5.969 0 0 0 6 21c1.282 0 2.47-.402 3.445-1.087.81.22 1.668.337 2.555.337Z" />
-                                </svg>
-                            </div>
-                            <div class="flex flex-col">
-                                <div class="font-semibold text-left">Languages</div>
-                                <div class="text-black text-left">{{ $case->languages->pluck('name')->implode(', ') }}</div>
-                            </div>
+                    <!-- Languages -->
+                    <div class="flex items-start mb-4">
+                        <div class="flex-shrink-0 mr-4">
+                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="var(--mint)" class="w-8 h-8 text-gray-600">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M12 20.25c4.97 0 9-3.694 9-8.25s-4.03-8.25-9-8.25S3 7.444 3 12c0 2.104.859 4.023 2.273 5.48.432.447.74 1.04.586 1.641a4.483 4.483 0 0 1-.923 1.785A5.969 5.969 0 0 0 6 21c1.282 0 2.47-.402 3.445-1.087.81.22 1.668.337 2.555.337Z" />
+                            </svg>
                         </div>
-
-                        <!-- Tags -->
-                        <div class="flex items-start">
-                            <div class="flex-shrink-0 mr-4">
-                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="var(--mint)" class="w-8 h-8 text-gray-600">
-                                    <path stroke-linecap="round" stroke-linejoin="round" d="M9.568 3H5.25A2.25 2.25 0 0 0 3 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 0 0 5.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 0 0 9.568 3Z" />
-                                    <path stroke-linecap="round" stroke-linejoin="round" d="M6 6h.008v.008H6V6Z" />
-                                </svg>
-                            </div>
-                            <div class="flex flex-col">
-                                <div class="font-semibold text-left">Tags</div>
-                                <div class="text-black text-left">{{ $case->tags->pluck('name')->implode(', ') }}</div>
-                            </div>
+                        <div class="flex flex-col">
+                            <div class="font-semibold text-left">Languages</div>
+                            <div class="text-black text-left">{{ $case->languages->pluck('name')->implode(', ') }}</div>
                         </div>
                     </div>
 
-                    <!-- Second Row Metadata-->
-                    <div class="grid grid-cols-1 md:grid-cols-2 gap-2">
-                        <!-- Countries Covered -->
-                        <div class="flex items-start">
-                            <div class="flex-shrink-0 mr-4">
-                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="var(--mint)" class="w-8 h-8 text-gray-600">
-                                    <path stroke-linecap="round" stroke-linejoin="round" d="m20.893 13.393-1.135-1.135a2.252 2.252 0 0 1-.421-.585l-1.08-2.16a.414.414 0 0 0-.663-.107.827.827 0 0 1-.812.21l-1.273-.363a.89.89 0 0 0-.738 1.595l.587.39c.59.395.674 1.23.172 1.732l-.2.2c-.212.212-.33.498-.33.796v.41c0 .409-.11.809-.32 1.158l-1.315 2.191a2.11 2.11 0 0 1-1.81 1.025 1.055 1.055 0 0 1-1.055-1.055v-1.172c0-.92-.56-1.747-1.414-2.089l-.655-.261a2.25 2.25 0 0 1-1.383-2.46l.007-.042a2.25 2.25 0 0 1 .29-.787l.09-.15a2.25 2.25 0 0 1 2.37-1.048l1.178.236a1.125 1.125 0 0 0 1.302-.795l.208-.73a1.125 1.125 0 0 0-.578-1.315l-.665-.332-.091.091a2.25 2.25 0 0 1-1.591.659h-.18c-.249 0-.487.1-.662.274a.931.931 0 0 1-1.458-1.137l1.411-2.353a2.25 2.25 0 0 0 .286-.76m11.928 9.869A9 9 0 0 0 8.965 3.525m11.928 9.868A9 9 0 1 1 8.965 3.525" />
-                                </svg>
-                            </div>
-                            <div class="flex flex-col">
-                                <div class="font-semibold text-left">Countries covered</div>
-                                <div class="text-black text-left">{{ $case->countries->pluck('name')->implode(', ') }}</div>
-                            </div>
+                    <!-- Countries Covered -->
+                    <div class="flex items-start">
+                        <div class="flex-shrink-0 mr-4">
+                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="var(--mint)" class="w-8 h-8 text-gray-600">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="m20.893 13.393-1.135-1.135a2.252 2.252 0 0 1-.421-.585l-1.08-2.16a.414.414 0 0 0-.663-.107.827.827 0 0 1-.812.21l-1.273-.363a.89.89 0 0 0-.738 1.595l.587.39c.59.395.674 1.23.172 1.732l-.2.2c-.212.212-.33.498-.33.796v.41c0 .409-.11.809-.32 1.158l-1.315 2.191a2.11 2.11 0 0 1-1.81 1.025 1.055 1.055 0 0 1-1.055-1.055v-1.172c0-.92-.56-1.747-1.414-2.089l-.655-.261a2.25 2.25 0 0 1-1.383-2.46l.007-.042a2.25 2.25 0 0 1 .29-.787l.09-.15a2.25 2.25 0 0 1 2.37-1.048l1.178.236a1.125 1.125 0 0 0 1.302-.795l.208-.73a1.125 1.125 0 0 0-.578-1.315l-.665-.332-.091.091a2.25 2.25 0 0 1-1.591.659h-.18c-.249 0-.487.1-.662.274a.931.931 0 0 1-1.458-1.137l1.411-2.353a2.25 2.25 0 0 0 .286-.76m11.928 9.869A9 9 0 0 0 8.965 3.525m11.928 9.868A9 9 0 1 1 8.965 3.525" />
+                            </svg>
                         </div>
-
-                        <!-- Geographic Area -->
-                        <div class="flex items-start">
-                            <div class="flex-shrink-0 mr-4">
-                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="var(--mint)" class="w-8 h-8 text-gray-600">
-                                    <path stroke-linecap="round" stroke-linejoin="round" d="M15 10.5a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
-                                    <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 10.5c0 7.142-7.5 11.25-7.5 11.25S4.5 17.642 4.5 10.5a7.5 7.5 0 1 1 15 0Z" />
-                                </svg>
-                            </div>
-                            <div class="flex flex-col">
-                                <div class="font-semibold text-left">Geographic area</div>
-                                <div class="text-black text-left">{{ $case->geographic_area }}</div>
-                            </div>
+                        <div class="flex flex-col">
+                            <div class="font-semibold text-left">Countries covered</div>
+                            <div class="text-black text-left">{{ $case->countries->pluck('name')->implode(', ') }}</div>
                         </div>
                     </div>
 

--- a/resources/views/livewire/search-cases.blade.php
+++ b/resources/views/livewire/search-cases.blade.php
@@ -254,63 +254,29 @@
                         <!-- Divider -->
                         <div class="h-1 w-full bg-teal my-3"></div>
 
-                        <!-- First Row Metadata -->
-                        <div class="grid grid-cols-1 sm:grid-cols-2 gap-2 mb-4">
-                            <!-- Languages -->
-                            <div class="flex items-start">
-                                <div class="flex-shrink-0 mr-4">
-                                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="var(--mint)" class="w-8 h-8 text-gray-600">
-                                        <path stroke-linecap="round" stroke-linejoin="round" d="M12 20.25c4.97 0 9-3.694 9-8.25s-4.03-8.25-9-8.25S3 7.444 3 12c0 2.104.859 4.023 2.273 5.48.432.447.74 1.04.586 1.641a4.483 4.483 0 0 1-.923 1.785A5.969 5.969 0 0 0 6 21c1.282 0 2.47-.402 3.445-1.087.81.22 1.668.337 2.555.337Z" />
-                                    </svg>
-                                </div>
-                                <div class="flex flex-col">
-                                    <div class="font-semibold text-left">Languages</div>
-                                    <div class="text-black text-left">{{ $case->languages->pluck('name')->implode(', ') }}</div>
-                                </div>
+                        <!-- Languages -->
+                        <div class="flex items-start mb-4">
+                            <div class="flex-shrink-0 mr-4">
+                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="var(--mint)" class="w-8 h-8 text-gray-600">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M12 20.25c4.97 0 9-3.694 9-8.25s-4.03-8.25-9-8.25S3 7.444 3 12c0 2.104.859 4.023 2.273 5.48.432.447.74 1.04.586 1.641a4.483 4.483 0 0 1-.923 1.785A5.969 5.969 0 0 0 6 21c1.282 0 2.47-.402 3.445-1.087.81.22 1.668.337 2.555.337Z" />
+                                </svg>
                             </div>
-
-                            <!-- Tags -->
-                            <div class="flex items-start">
-                                <div class="flex-shrink-0 mr-4">
-                                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="var(--mint)" class="w-8 h-8 text-gray-600">
-                                        <path stroke-linecap="round" stroke-linejoin="round" d="M9.568 3H5.25A2.25 2.25 0 0 0 3 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 0 0 5.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 0 0 9.568 3Z" />
-                                        <path stroke-linecap="round" stroke-linejoin="round" d="M6 6h.008v.008H6V6Z" />
-                                    </svg>
-                                </div>
-                                <div class="flex flex-col">
-                                    <div class="font-semibold text-left">Tags</div>
-                                    <div class="text-black text-left">{{ $case->tags->pluck('name')->implode(', ') }}</div>
-                                </div>
+                            <div class="flex flex-col">
+                                <div class="font-semibold text-left">Languages</div>
+                                <div class="text-black text-left">{{ $case->languages->pluck('name')->implode(', ') }}</div>
                             </div>
                         </div>
 
-                        <!-- Second Row Metadata-->
-                        <div class="grid grid-cols-1 md:grid-cols-2 gap-2">
-                            <!-- Countries Covered -->
-                            <div class="flex items-start">
-                                <div class="flex-shrink-0 mr-4">
-                                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="var(--mint)" class="w-8 h-8 text-gray-600">
-                                        <path stroke-linecap="round" stroke-linejoin="round" d="m20.893 13.393-1.135-1.135a2.252 2.252 0 0 1-.421-.585l-1.08-2.16a.414.414 0 0 0-.663-.107.827.827 0 0 1-.812.21l-1.273-.363a.89.89 0 0 0-.738 1.595l.587.39c.59.395.674 1.23.172 1.732l-.2.2c-.212.212-.33.498-.33.796v.41c0 .409-.11.809-.32 1.158l-1.315 2.191a2.11 2.11 0 0 1-1.81 1.025 1.055 1.055 0 0 1-1.055-1.055v-1.172c0-.92-.56-1.747-1.414-2.089l-.655-.261a2.25 2.25 0 0 1-1.383-2.46l.007-.042a2.25 2.25 0 0 1 .29-.787l.09-.15a2.25 2.25 0 0 1 2.37-1.048l1.178.236a1.125 1.125 0 0 0 1.302-.795l.208-.73a1.125 1.125 0 0 0-.578-1.315l-.665-.332-.091.091a2.25 2.25 0 0 1-1.591.659h-.18c-.249 0-.487.1-.662.274a.931.931 0 0 1-1.458-1.137l1.411-2.353a2.25 2.25 0 0 0 .286-.76m11.928 9.869A9 9 0 0 0 8.965 3.525m11.928 9.868A9 9 0 1 1 8.965 3.525" />
-                                    </svg>
-                                </div>
-                                <div class="flex flex-col">
-                                    <div class="font-semibold text-left">Countries covered</div>
-                                    <div class="text-black text-left">{{ $case->countries->pluck('name')->implode(', ') }}</div>
-                                </div>
+                        <!-- Countries Covered -->
+                        <div class="flex items-start">
+                            <div class="flex-shrink-0 mr-4">
+                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="var(--mint)" class="w-8 h-8 text-gray-600">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="m20.893 13.393-1.135-1.135a2.252 2.252 0 0 1-.421-.585l-1.08-2.16a.414.414 0 0 0-.663-.107.827.827 0 0 1-.812.21l-1.273-.363a.89.89 0 0 0-.738 1.595l.587.39c.59.395.674 1.23.172 1.732l-.2.2c-.212.212-.33.498-.33.796v.41c0 .409-.11.809-.32 1.158l-1.315 2.191a2.11 2.11 0 0 1-1.81 1.025 1.055 1.055 0 0 1-1.055-1.055v-1.172c0-.92-.56-1.747-1.414-2.089l-.655-.261a2.25 2.25 0 0 1-1.383-2.46l.007-.042a2.25 2.25 0 0 1 .29-.787l.09-.15a2.25 2.25 0 0 1 2.37-1.048l1.178.236a1.125 1.125 0 0 0 1.302-.795l.208-.73a1.125 1.125 0 0 0-.578-1.315l-.665-.332-.091.091a2.25 2.25 0 0 1-1.591.659h-.18c-.249 0-.487.1-.662.274a.931.931 0 0 1-1.458-1.137l1.411-2.353a2.25 2.25 0 0 0 .286-.76m11.928 9.869A9 9 0 0 0 8.965 3.525m11.928 9.868A9 9 0 1 1 8.965 3.525" />
+                                </svg>
                             </div>
-
-                            <!-- Geographic Area -->
-                            <div class="flex items-start">
-                                <div class="flex-shrink-0 mr-4">
-                                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="var(--mint)" class="w-8 h-8 text-gray-600">
-                                        <path stroke-linecap="round" stroke-linejoin="round" d="M15 10.5a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
-                                        <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 10.5c0 7.142-7.5 11.25-7.5 11.25S4.5 17.642 4.5 10.5a7.5 7.5 0 1 1 15 0Z" />
-                                    </svg>
-                                </div>
-                                <div class="flex flex-col">
-                                    <div class="font-semibold text-left">Geographic Area</div>
-                                    <div class="text-black text-left">{{ $case->geographic_area }}</div>
-                                </div>
+                            <div class="flex flex-col">
+                                <div class="font-semibold text-left">Countries covered</div>
+                                <div class="text-black text-left">{{ $case->countries->pluck('name')->implode(', ') }}</div>
                             </div>
                         </div>
                     </div>

--- a/resources/views/livewire/search-cases.blade.php
+++ b/resources/views/livewire/search-cases.blade.php
@@ -92,6 +92,35 @@
                 </div>
             </div>
 
+            <!-- Indicator Filter -->
+            <div class="relative inline-block text-left" @click.outside="openDropdown = openDropdown === 'indicator' ? null : openDropdown">
+                <button @click="openDropdown = openDropdown === 'indicator' ? null : 'indicator'" class="inline-flex justify-center w-full rounded-full border border-dark-teal px-4 py-2 bg-dark-teal text-white font-medium cursor-pointer">
+                    INDICATOR
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-5 h-5 ml-2">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
+                    </svg>
+                </button>
+
+                <!-- Indicator Dropdown Menu -->
+                <div x-show="openDropdown === 'indicator'" class="origin-top-right absolute right-0 mt-2 w-56 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 focus:outline-none">
+                    <div class="py-1">
+                        <a href="#" class="block px-4 py-2 text-sm text-dark-teal hover:bg-light-green hover:text-black"
+                        wire:click.prevent="toggleFilter('indicator', null)">
+                            All Indicators
+                        </a>
+                        @foreach($indicators as $indicator)
+                            <a href="#" class="block px-4 py-2 text-sm text-dark-teal hover:bg-light-green hover:text-black"
+                            wire:click.prevent="toggleFilter('indicator', {{ $indicator->id }})">
+                            {{ $indicator->name }} 
+                            @if(collect($selectedIndicators)->contains($indicator->id))
+                                <span class="ml-2 text-mint">&#x2714;</span> <!-- Adds a checkmark if selected -->
+                            @endif
+                            </a>
+                        @endforeach
+                    </div>
+                </div>
+            </div>
+
             <!-- Country Filter -->
             <div class="relative inline-block text-left" @click.outside="openDropdown = openDropdown === 'country' ? null : openDropdown">
                 <button @click="openDropdown = openDropdown === 'country' ? null : 'country'" class="inline-flex justify-center w-full rounded-full border border-dark-teal px-4 py-2 bg-dark-teal text-white font-medium cursor-pointer">
@@ -155,6 +184,20 @@
                             </svg>
                         </button>
                         <span class="font-semibold">{{ mb_strtoupper($tags->find($tagId)->name, 'UTF-8') }}</span>
+                    </div>
+                @endif
+            @endforeach
+
+            <!-- Selected Indicators -->
+            @foreach($selectedIndicators as $indicatorId)
+                @if($indicatorId && $indicators->find($indicatorId))
+                    <div class="flex items-center bg-pale-green text-dark-teal rounded-full px-4 py-2">
+                        <button wire:click.prevent="toggleFilter('indicator', {{ $indicatorId }})" class="mr-2 text-dark-teal">
+                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" class="w-5 h-5">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+                            </svg>
+                        </button>
+                        <span class="font-semibold">{{ mb_strtoupper($indicators->find($indicatorId)->name, 'UTF-8') }}</span>
                     </div>
                 @endif
             @endforeach


### PR DESCRIPTION
Frontend changes:

- deletes subheadings in case details
- moves communication products to top of catalogue
- changes heading 'the case as presented’ to ‘Communication product(s)’
- removes forced uppercase on titles
- removes tags and geographic area from the case cards on the home page
- adds a filter for indicators on the homepage search
- when evidence has been been marked as being a communication product, a link to the communication products section is displayed


Backend changes:
- removes note section from case details
- adds option for evidence to be marked as being a communication product of the case
- improves breadcrumbs on claims editing so that user goes back to the claims of the case and not claims of all cases