### PR TITLE
Revise Admin Panel App Panel

### DIFF
--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -43,7 +43,7 @@ class AdminPanelProvider extends PanelProvider
             ->homeUrl('/home')
             ->darkMode(false)
             ->colors([
-                'primary' => Color::Amber,
+                'primary' => Color::Red,
             ])
             ->discoverResources(in: app_path('Filament/Admin/Resources'), for: 'App\\Filament\\Admin\\Resources')
             ->discoverPages(in: app_path('Filament/Admin/Pages'), for: 'App\\Filament\\Admin\\Pages')

--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -47,6 +47,8 @@ class AppPanelProvider extends PanelProvider
             ])
             ->login()
             ->passwordReset()
+            // change sidebar to top navigation, to discriminate from Admin panel
+            ->topNavigation()
             ->profile() // TODO: Implement more full-featured profile page
             ->darkMode(false)
             ->colors([
@@ -93,11 +95,12 @@ class AppPanelProvider extends PanelProvider
                     ...StudyCaseResource::getNavigationItems(),
                 ])
                     ->groups([
-                        NavigationGroup::make('Definitions')
-                            ->label(t('Definitions'))
-                            ->items([
-                                ...OrganisationResource::getNavigationItems(),
-                            ]),
+                        // remove "Partner Organisations" from sidebar
+                        // NavigationGroup::make('Definitions')
+                        //     ->label(t('Definitions'))
+                        //     ->items([
+                        //         ...OrganisationResource::getNavigationItems(),
+                        //     ]),
                         // create a navigation group without label, nothing will be showed for non admin user
                         NavigationGroup::make('')
                             ->items([


### PR DESCRIPTION
This PR is submitted to fix https://github.com/stats4sd/aef/issues/106 and fix https://github.com/stats4sd/aef/issues/109

Some changes will be more suitable to add after revising study case resource structure.

It is now ready for review.

---

It contains below changes:
 - Admin panel, change color from yellow to red
 - App panel, hide "Partner Organisations" from sidebar
 - App panel, change from sidebar navigation to top navigation

---

Below items will be developed in other PRs:
 - Admin panel, change item label from "Return to Front-end" to "Return to App panel"
   - We need to support multiple languages. Label "Return to Front-end" needs to be updated in translation.io
 - StudyCaseResource, to be implemented after restrcuture
   - For the Year of development, can we set it to the current year by default (with the option to change it)
   - In the main CaseResource list table, swap the 2 boolean fields for a single status field.
   - I think for now we should completely hide the "confirmation" tab unless the user is an admin.
