### PR TITLE
Study Case Editing

### DIFF
--- a/app/Enums/StudyCaseStatus.php
+++ b/app/Enums/StudyCaseStatus.php
@@ -4,15 +4,18 @@ namespace App\Enums;
 
 use Filament\Support\Contracts\HasLabel;
 use Filament\Support\Contracts\HasDescription;
+use Filament\Support\Contracts\HasColor;
 
-enum StudyCaseStatus: string implements HasLabel, HasDescription
+enum StudyCaseStatus: string implements HasLabel, HasDescription, HasColor
 {
+    // define string values
     case Proposal = 'proposal';
     case Closed = 'closed';
     case Development = 'development';
     case ReadyForReview = 'ready_for_review';
     case Reviewed = 'reviewed';
 
+    // define labels
     public function getLabel(): ?string
     {
         return match ($this) {
@@ -24,6 +27,7 @@ enum StudyCaseStatus: string implements HasLabel, HasDescription
         };
     }
 
+    // define descritpions
     public function getDescription(): ?string
     {
         // Proposal       : user created a new study case (assumes user will inform reviewer offline when the study case is ready for review)
@@ -38,6 +42,23 @@ enum StudyCaseStatus: string implements HasLabel, HasDescription
             self::Development => 'This has been reviewed by reviewer, and decided to further develop',
             self::ReadyForReview => 'This is ready for a reviewer to review',
             self::Reviewed => 'This has been approved by a reviewer. This has been published on the website',
+        };
+    }
+
+    // define badge colors
+    public function getColor(): string | array | null
+    {
+        // warning (yellow) : pending on reviewer to review
+        // danger (red)     : unsuccessful study case that decided not to further develop
+        // gray (gray)      : no action required from reviewer
+        // success (green)  : reviewer has reviewed and published
+
+        return match ($this) {
+            self::Proposal => 'warning',
+            self::Closed => 'danger',
+            self::Development => 'gray',
+            self::ReadyForReview => 'warning',
+            self::Reviewed => 'success',            
         };
     }
 }

--- a/app/Enums/StudyCaseStatus.php
+++ b/app/Enums/StudyCaseStatus.php
@@ -8,7 +8,7 @@ use Filament\Support\Contracts\HasDescription;
 enum StudyCaseStatus: string implements HasLabel, HasDescription
 {
     case Proposal = 'proposal';
-    case ReadyForDevelopment = 'ready_for_development';
+    case Closed = 'closed';
     case Development = 'development';
     case ReadyForReview = 'ready_for_review';
     case Reviewed = 'reviewed';
@@ -17,7 +17,7 @@ enum StudyCaseStatus: string implements HasLabel, HasDescription
     {
         return match ($this) {
             self::Proposal => 'Proposal',
-            self::ReadyForDevelopment => 'Ready for development',
+            self::Closed => 'Closed',
             self::Development => 'Development',
             self::ReadyForReview => 'Ready for review',
             self::Reviewed => 'Reviewed',
@@ -26,16 +26,16 @@ enum StudyCaseStatus: string implements HasLabel, HasDescription
 
     public function getDescription(): ?string
     {
-        // Proposal            : user created a new study case
-        // ReadyForDevelopment : user has filled in study case details; user requests reviewer to approve
-        // Development         : reviewer approved study case; user can further develop by filling in more details
-        // ReadyForReview      : user has filled in all necessary details; user request reviewer to review
-        // Reviewed            : reviewer approved study case; study case is published on the website
+        // Proposal       : user created a new study case (assumes user will inform reviewer offline when the study case is ready for review)
+        // Closed         : reviewer reviewed and decided NOT to further develop
+        // Development    : reviewer reviewed and decided to further develop
+        // ReadyForReview : user has filled in all necessary details; user request reviewer to review
+        // Reviewed       : reviewer approved study case; study case is published on the website
         
         return match ($this) {
             self::Proposal => 'This has not finished being written yet.',
-            self::ReadyForDevelopment => 'This has enough details. User requested reviewer to approve.',
-            self::Development => 'This has been approved by reviewer to further develop',
+            self::Closed => 'This has been reviewed by reviewer, and decided NOT to further develop',
+            self::Development => 'This has been reviewed by reviewer, and decided to further develop',
             self::ReadyForReview => 'This is ready for a reviewer to review',
             self::Reviewed => 'This has been approved by a reviewer. This has been published on the website',
         };

--- a/app/Filament/Admin/Resources/StudyCaseResource.php
+++ b/app/Filament/Admin/Resources/StudyCaseResource.php
@@ -22,7 +22,7 @@ use App\Filament\Admin\Resources\StudyCaseResource\RelationManagers;
 use App\Filament\App\Resources\StudyCaseResource as AppPanelStudyCaseResource;
 use App\Filament\Admin\Resources\StudyCaseResource\Pages\ListStudyCases as AdminPanelListStudyCases;
 use App\Filament\App\Resources\StudyCaseResource\RelationManagers\ClaimsRelationManager as AppPanelClaimsRelationManager;
-
+use Filament\Tables\Filters\Filter;
 
 class StudyCaseResource extends Resource
 {
@@ -84,10 +84,22 @@ class StudyCaseResource extends Resource
                     ->wrapHeader(),
                 Tables\Columns\TextColumn::make('status')
                     ->label(t('Status'))
+                    ->badge()
                     ->sortable(),
 
             ])
             ->filters([
+                // apply this filter by default to exclude study case with status "closed"
+                //
+                // To show study cases with "closed" status, user needs to:
+                // 1. untick the checkbox of this filter
+                // 2. select "Closed" in "status" filter
+                Filter::make('hide_closed_cases')
+                    ->label('Hide closed cases')
+                    ->default()
+                    ->query(fn (Builder $query): Builder => $query->where('status', '!=', 'closed')),
+
+                // this filter works properly to show study cases for a selected status
                 SelectFilter::make('status')
                     ->options(StudyCaseStatus::class),
             ])

--- a/app/Filament/Admin/Resources/StudyCaseResource.php
+++ b/app/Filament/Admin/Resources/StudyCaseResource.php
@@ -7,20 +7,21 @@ use Filament\Tables;
 use Filament\Forms\Form;
 use App\Models\StudyCase;
 use Filament\Tables\Table;
+use App\Enums\StudyCaseStatus;
 use Filament\Resources\Resource;
+use Filament\Resources\Pages\Page;
 use Filament\Forms\Components\Tabs;
 use Filament\Forms\Components\TextInput;
+use Filament\Pages\SubNavigationPosition;
 use Filament\Tables\Filters\SelectFilter;
 use Illuminate\Database\Eloquent\Builder;
 use Filament\Tables\Filters\TernaryFilter;
 use Illuminate\Database\Eloquent\SoftDeletingScope;
-use App\Filament\App\Resources\StudyCaseResource as AppPanelStudyCaseResource;
-use App\Filament\App\Resources\StudyCaseResource\RelationManagers\ClaimsRelationManager as AppPanelClaimsRelationManager;
-use App\Filament\Admin\Resources\StudyCaseResource\RelationManagers;
-use Filament\Pages\SubNavigationPosition;
-use Filament\Resources\Pages\Page;
 use App\Filament\App\Resources\StudyCaseResource\Pages;
+use App\Filament\Admin\Resources\StudyCaseResource\RelationManagers;
+use App\Filament\App\Resources\StudyCaseResource as AppPanelStudyCaseResource;
 use App\Filament\Admin\Resources\StudyCaseResource\Pages\ListStudyCases as AdminPanelListStudyCases;
+use App\Filament\App\Resources\StudyCaseResource\RelationManagers\ClaimsRelationManager as AppPanelClaimsRelationManager;
 
 
 class StudyCaseResource extends Resource
@@ -81,19 +82,14 @@ class StudyCaseResource extends Resource
                     ->sortable()
                     ->searchable()
                     ->wrapHeader(),
-                Tables\Columns\IconColumn::make('ready_for_review')
-                    ->label(t('Ready for review'))
-                    ->boolean()
-                    ->sortable()
-                    ->wrapHeader(),
-                Tables\Columns\IconColumn::make('reviewed')
-                    ->label(t('Reviewed'))
-                    ->boolean()
+                Tables\Columns\TextColumn::make('status')
+                    ->label(t('Status'))
                     ->sortable(),
+
             ])
             ->filters([
-                TernaryFilter::make('ready_for_review')->label(t('Ready for review')),
-                TernaryFilter::make('reviewed')->label(t('Reviewed')),
+                SelectFilter::make('status')
+                    ->options(StudyCaseStatus::class),
             ])
             ->actions([
                 Tables\Actions\EditAction::make(),

--- a/app/Filament/Admin/Resources/StudyCaseResource.php
+++ b/app/Filament/Admin/Resources/StudyCaseResource.php
@@ -20,6 +20,8 @@ use App\Filament\Admin\Resources\StudyCaseResource\RelationManagers;
 use Filament\Pages\SubNavigationPosition;
 use Filament\Resources\Pages\Page;
 use App\Filament\App\Resources\StudyCaseResource\Pages;
+use App\Filament\Admin\Resources\StudyCaseResource\Pages\ListStudyCases as AdminPanelListStudyCases;
+
 
 class StudyCaseResource extends Resource
 {
@@ -119,13 +121,8 @@ class StudyCaseResource extends Resource
     public static function getPages(): array
     {
         return [
-            'index' => Pages\ListStudyCases::route('/'),
-
-            // TODO:
-            // remove or disable route for creating a new study case
-            // reviewer should not be able to create new study case.
-            // study case should be created by leading organisation member.
-            'create' => Pages\CreateStudyCase::route('/create'),
+            // use admin panel ListStudyCases, so that it will use table() function of this class
+            'index' => AdminPanelListStudyCases::route('/'),
 
             'edit-basic-information' => Pages\EditBasicInformation::route('/{record}/edit-basic-information'),
             'edit-case-details' => Pages\EditCaseDetails::route('/{record}/edit-case-details'),

--- a/app/Filament/App/Resources/StudyCaseResource.php
+++ b/app/Filament/App/Resources/StudyCaseResource.php
@@ -28,19 +28,20 @@ class StudyCaseResource extends Resource
 
     public static function getRecordSubNavigation(Page $page): array
     {
-        // Question: how to hide (or not adding) Confirmation page when study case status is Proposal?
-        //
-        // For case submitter to view study case with Proposal status, we may considered to show a message to indicate that 
-        // this study case is pending on reviewer to review and determine to further develop or close
-
-        return $page->generateNavigationItems([
+        $navigation = [
             Pages\EditBasicInformation::class,
             Pages\EditCaseDetails::class,
             Pages\EditCommunicationProducts::class,
             Pages\EditPhotos::class,
             Pages\ManageCaseStudyClaims::class,
-            Pages\EditConfirmation::class,
-        ]);
+        ];
+
+        // only show confirmation step if case is not in proposal stage
+        if ($page->getRecord()?->status !== StudyCaseStatus::Proposal) {
+            $navigation[] = Pages\EditConfirmation::class;
+        }
+
+        return $page->generateNavigationItems($navigation);
     }
 
     // define translatable string in function

--- a/app/Filament/App/Resources/StudyCaseResource.php
+++ b/app/Filament/App/Resources/StudyCaseResource.php
@@ -71,6 +71,7 @@ class StudyCaseResource extends Resource
                     ->wrapHeader(),
                 Tables\Columns\TextColumn::make('status')
                     ->label(t('Status'))
+                    ->badge()
                     ->sortable(),
             ])
             ->filters([

--- a/app/Filament/App/Resources/StudyCaseResource.php
+++ b/app/Filament/App/Resources/StudyCaseResource.php
@@ -28,6 +28,8 @@ class StudyCaseResource extends Resource
 
     public static function getRecordSubNavigation(Page $page): array
     {
+        // Question: how to hide (or not adding) Confirmation page when study case status is Proposal?
+
         return $page->generateNavigationItems([
             Pages\EditBasicInformation::class,
             Pages\EditCaseDetails::class,

--- a/app/Filament/App/Resources/StudyCaseResource.php
+++ b/app/Filament/App/Resources/StudyCaseResource.php
@@ -29,6 +29,9 @@ class StudyCaseResource extends Resource
     public static function getRecordSubNavigation(Page $page): array
     {
         // Question: how to hide (or not adding) Confirmation page when study case status is Proposal?
+        //
+        // For case submitter to view study case with Proposal status, we may considered to show a message to indicate that 
+        // this study case is pending on reviewer to review and determine to further develop or close
 
         return $page->generateNavigationItems([
             Pages\EditBasicInformation::class,

--- a/app/Filament/App/Resources/StudyCaseResource/Pages/EditBasicInformation.php
+++ b/app/Filament/App/Resources/StudyCaseResource/Pages/EditBasicInformation.php
@@ -113,7 +113,7 @@ class EditBasicInformation extends EditRecord
 
                     Section::make(t('Leading organisation'))
                         // hide this section when status is Proposal or Ready for development
-                        ->hidden(fn ($record) => $record->status == StudyCaseStatus::Proposal || $record->status == StudyCaseStatus::ReadyForDevelopment)
+                        ->hidden(fn ($record) => $record->status == StudyCaseStatus::Proposal)
                         ->schema([
                             Placeholder::make('leading_organisation')
                                 ->label(t('Organisation name'))
@@ -133,7 +133,7 @@ class EditBasicInformation extends EditRecord
 
                     Section::make(t('Partner organisation(s)'))
                         // hide this section when status is Proposal or Ready for development
-                        ->hidden(fn ($record) => $record->status == StudyCaseStatus::Proposal || $record->status == StudyCaseStatus::ReadyForDevelopment)
+                        ->hidden(fn ($record) => $record->status == StudyCaseStatus::Proposal)
                         ->schema([
                             Select::make('organisations')
                                 ->label(t('Partner organisation(s)'))

--- a/app/Filament/App/Resources/StudyCaseResource/Pages/EditBasicInformation.php
+++ b/app/Filament/App/Resources/StudyCaseResource/Pages/EditBasicInformation.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\App\Resources\StudyCaseResource\Pages;
 
+use App\Enums\StudyCaseStatus;
 use App\Filament\App\Resources\StudyCaseResource;
 use App\Models\StudyCase;
 use Filament\Actions;
@@ -111,6 +112,8 @@ class EditBasicInformation extends EditRecord
                         ->columnSpanFull(),
 
                     Section::make(t('Leading organisation'))
+                        // hide this section when status is Proposal or Ready for development
+                        ->hidden(fn ($record) => $record->status == StudyCaseStatus::Proposal || $record->status == StudyCaseStatus::ReadyForDevelopment)
                         ->schema([
                             Placeholder::make('leading_organisation')
                                 ->label(t('Organisation name'))
@@ -129,6 +132,8 @@ class EditBasicInformation extends EditRecord
                         ]),
 
                     Section::make(t('Partner organisation(s)'))
+                        // hide this section when status is Proposal or Ready for development
+                        ->hidden(fn ($record) => $record->status == StudyCaseStatus::Proposal || $record->status == StudyCaseStatus::ReadyForDevelopment)
                         ->schema([
                             Select::make('organisations')
                                 ->label(t('Partner organisation(s)'))

--- a/app/Filament/App/Resources/StudyCaseResource/Pages/EditConfirmation.php
+++ b/app/Filament/App/Resources/StudyCaseResource/Pages/EditConfirmation.php
@@ -54,30 +54,8 @@ class EditConfirmation extends EditRecord
     protected function getHeaderActions(): array
     {
         return [
-            // TODO: check if user has ticked checkbox "request_for_development"
+            // TODO: check if user has ticked checkbox
             // TODO: it is more preferred to move this button inside the corresponding section, instead of adding it as a header button
-
-            // Proposal for case submitter
-            Actions\Action::make('send_request_for_development')
-                ->label('Send request')
-                ->requiresConfirmation()
-                ->visible(fn($record) => $record->status == StudyCaseStatus::Proposal && !auth()->user()->isAdmin())
-                // Question: How to check if user has ticked checkbox when user click "Send request" button?
-                ->action(function ($record) {                    
-                    $record->status = StudyCaseStatus::ReadyForDevelopment;
-                    $record->save();
-                }),
-
-            // Ready for development for reviewer
-            Actions\Action::make('approve_request_for_development')
-                ->label('Approve')
-                ->requiresConfirmation()
-                ->visible(fn($record) => $record->status == StudyCaseStatus::ReadyForDevelopment && auth()->user()->isAdmin())
-                // Question: How to check if user has ticked checkbox when user click "Approve" button?
-                ->action(function ($record) {                    
-                    $record->status = StudyCaseStatus::Development;
-                    $record->save();
-                }),
 
             // Development for case submitter
             Actions\Action::make('send_request_for_review')
@@ -110,47 +88,6 @@ class EditConfirmation extends EditRecord
         // show the corresponding section per status per role
 
         return $form->schema([
-
-            // Proposal for case submitter
-            Section::make(t('Case Submitter Confirmation'))
-                ->icon('heroicon-o-check-circle')
-                ->description(t('Request to change status from Proposal to Development'))
-                ->visible(fn($record) => $record->status == StudyCaseStatus::Proposal && !auth()->user()->isAdmin())
-                ->schema([
-                    Checkbox::make('request_for_development')
-                        ->label(t('I confirm that all content is correct. This case is now ready for development.'))
-                        ->hint(t('This is to be confirmed by case submitter'))
-                        // Note: Validation is performed when user click "Save changes" button. ("Save changes" button is already hidden)
-                        // No validation is performed when user click "Send request" button.
-                        ->accepted()
-                        ->columnSpanFull(),
-               ]),
-
-            // Proposal for reviewer
-            Section::make(t('Status is Proposal'))
-                ->icon('heroicon-o-check-circle')
-                ->description(t('Case submitter is filling study case details.'))
-                ->visible(fn($record) => $record->status == StudyCaseStatus::Proposal && auth()->user()->isAdmin()),
-
-
-            // Ready for development for case submitter
-            Section::make(t('Status is Ready for development'))
-                ->icon('heroicon-o-check-circle')
-                ->description(t('It is now pending on reviewer to approve to change status to Development'))
-                ->visible(fn($record) => $record->status == StudyCaseStatus::ReadyForDevelopment && !auth()->user()->isAdmin()),
-
-            // Ready for development for reviewer
-            Section::make(t('Case Reviewer Confirmation'))
-                ->icon('heroicon-o-check-circle')
-                ->description(t('Request to change status from Proposal to Development'))
-                ->visible(fn($record) => $record->status == StudyCaseStatus::ReadyForDevelopment && auth()->user()->isAdmin())
-                ->schema([
-                    Checkbox::make('approve_for_development')
-                        ->label(t('I confirm that all content is correct. This case is now ready for development.'))
-                        ->hint(t('This is to be confirmed by case reviewer'))
-                        ->columnSpanFull(),
-                ]),
-
 
             // Development for submitter
             Section::make(t('Case Submitter Confirmation'))

--- a/app/Filament/App/Resources/StudyCaseResource/Pages/EditConfirmation.php
+++ b/app/Filament/App/Resources/StudyCaseResource/Pages/EditConfirmation.php
@@ -57,6 +57,24 @@ class EditConfirmation extends EditRecord
             // TODO: check if user has ticked checkbox
             // TODO: it is more preferred to move this button inside the corresponding section, instead of adding it as a header button
 
+            // Proposal for reviewer, further develop proposal
+            Actions\Action::make('further_develop_proposal')
+                ->requiresConfirmation()
+                ->visible(fn($record) => $record->status == StudyCaseStatus::Proposal && auth()->user()->isAdmin())
+                ->action(function ($record) {                    
+                    $record->status = StudyCaseStatus::Development;
+                    $record->save();
+                }),
+
+            // Proposal for reviewer, close proposal
+            Actions\Action::make('close_proposal')
+                ->requiresConfirmation()
+                ->visible(fn($record) => $record->status == StudyCaseStatus::Proposal && auth()->user()->isAdmin())
+                ->action(function ($record) {                    
+                    $record->status = StudyCaseStatus::Closed;
+                    $record->save();
+                }),
+
             // Development for case submitter
             Actions\Action::make('send_request_for_review')
                 ->label('Send request')
@@ -88,6 +106,26 @@ class EditConfirmation extends EditRecord
         // show the corresponding section per status per role
 
         return $form->schema([
+
+            // Proposal for submitter
+            Section::make(t('Proposal to be reviewed'))
+                ->icon('heroicon-o-check-circle')
+                ->description(t('It is now pending on reviewer to review and determine to further develop or close this study case'))
+                ->visible(fn($record) => $record->status == StudyCaseStatus::Proposal && !auth()->user()->isAdmin()),
+                
+            // Proposal for reviewer
+            Section::make(t('Case Reviewer Confirmation'))
+                ->icon('heroicon-o-check-circle')
+                ->description(t('Review and determine to further develop or close this study case'))
+                ->visible(fn($record) => $record->status == StudyCaseStatus::Proposal && auth()->user()->isAdmin()),
+
+
+            // Closed
+            Section::make(t('Reviewed and closed'))
+                ->icon('heroicon-o-check-circle')
+                ->description(t('The case has been reviewed and closed'))
+                ->visible(fn($record) => $record->status == StudyCaseStatus::Closed),
+
 
             // Development for submitter
             Section::make(t('Case Submitter Confirmation'))

--- a/app/Models/StudyCase.php
+++ b/app/Models/StudyCase.php
@@ -63,6 +63,11 @@ class StudyCase extends Model implements HasMedia
                 }
             }
         });
+
+        // newly created study case should have status "Proposal"
+        static::creating(function ($item) {
+            $item->status = StudyCaseStatus::Proposal;
+        });
     }
 
     // leading organisation


### PR DESCRIPTION
This PR is submitted to fix https://github.com/stats4sd/aef/issues/102

It is not yet ready for review. It is submitted for progress update.

---

It contains below changes:
 - [x] set status to "Proposal" for newly created study case
 - [x] for Proposal stage cases, hide leading organisation and partner orgs section
 - [x] remove status Ready for Development and related code; add status Closed
 - [x] StudyCaseResurce, add code for "Further Develop" and "Close"
 - [x] admin panel > StudyCaseResource, add filter for status
 - [x] admin panel > StudyCaseResource, do not show study case with status "Closed" by default
 - [ ] StudyCaseResource, hide Confirmation page (or not adding it) when status is "Proposal"