### PR TITLE
Review Preview Page

### DIFF
--- a/resources/views/cases/other.blade.php
+++ b/resources/views/cases/other.blade.php
@@ -74,11 +74,17 @@
                         </div>
                     @endif
 
-                    <div class="col-span-3 lg:col-span-1 pt-2 md:pt-0 font-semibold text-lg text-left">{{ t("Contact") }}</div>
-                    <div class="col-span-5 lg:col-span-5 text-left sm:flex items-center">
-                        <span class="text-black inline">{{ $studycase->contact_person_name }} | </span>
-                        <span class="text-ochre block sm:inline sm:ml-1">{{ $studycase->contact_person_email }}</span>
-                    </div>
+                    <!-- Study case with status Proposal and Closed does not have leading organisation contact person details yet -->
+                    @if($studycase->status == App\Enums\StudyCaseStatus::Development || 
+                        $studycase->status == App\Enums\StudyCaseStatus::ReadyForReview || 
+                        $studycase->status == App\Enums\StudyCaseStatus::Reviewed)
+                        <div class="col-span-3 lg:col-span-1 pt-2 md:pt-0 font-semibold text-lg text-left">{{ t("Contact") }}</div>
+                        <div class="col-span-5 lg:col-span-5 text-left sm:flex items-center">
+                            <span class="text-black inline">{{ $studycase->contact_person_name }} | </span>
+                            <span class="text-ochre block sm:inline sm:ml-1">{{ $studycase->contact_person_email }}</span>
+                        </div>
+                    @endif
+
                 </div>
             </div>
         </div>


### PR DESCRIPTION
This PR is submitted to fix https://github.com/stats4sd/aef/issues/104

It is not yet ready for review. It is submitted for progress update.

---

It contains below changes:
 - [x] study case Preview page, do not show leading organisation contact person when status is Proposal and Closed
 - [ ] study case Preview page, add access control
    - [ ] Admin and all teammates of case creator can access for all status
    - [ ] Public can only access study case when status is REVIEWED